### PR TITLE
Install gcc in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,6 @@ EXPOSE     9091
 WORKDIR    /pushgateway
 ENTRYPOINT [ "/pushgateway/bin/pushgateway" ]
 
-RUN        apt-get -qy update && apt-get install -yq make git curl sudo mercurial vim-common
+RUN        apt-get -qy update && apt-get install -yq make git curl sudo mercurial gcc
 ADD        . /pushgateway
 RUN        make bin/pushgateway


### PR DESCRIPTION
With procfs we now depend on gcc.
This also removes vim-common which isn't used.