### PR TITLE
Remove internal metrics.

### DIFF
--- a/main.go
+++ b/main.go
@@ -21,7 +21,6 @@ import (
 	"net/http/pprof"
 	"os"
 	"os/signal"
-	"runtime"
 	"syscall"
 	"time"
 
@@ -37,94 +36,7 @@ var (
 	metricsPath         = flag.String("web.telemetry-path", "/metrics", "Path under which to expose metrics.")
 	persistenceFile     = flag.String("persistence.file", "", "File to persist metrics. If empty, metrics are only kept in memory.")
 	persistenceInterval = flag.Duration("persistence.interval", 5*time.Minute, "The minimum interval at which to write out the persistence file.")
-
-	im = internalMetrics{
-		{
-			desc: prometheus.NewDesc(
-				"runtime_goroutines_count",
-				"Number of goroutines that currently exist.",
-				nil, nil,
-			),
-			eval:    func(ms *runtime.MemStats) float64 { return float64(runtime.NumGoroutine()) },
-			valType: prometheus.GaugeValue,
-			// Not a counter, despite the name... It can go up and down.
-		},
-		{
-			desc: prometheus.NewDesc(
-				"runtime_memory_allocated_bytes",
-				"Bytes allocated and still in use.",
-				nil, nil,
-			),
-			eval:    func(ms *runtime.MemStats) float64 { return float64(ms.Alloc) },
-			valType: prometheus.GaugeValue,
-		},
-		{
-			desc: prometheus.NewDesc(
-				"runtime_memory_allocated_bytes_total",
-				"Total bytes ever allocated (even if freed).",
-				nil, nil,
-			),
-			eval:    func(ms *runtime.MemStats) float64 { return float64(ms.TotalAlloc) },
-			valType: prometheus.CounterValue,
-		},
-		{
-			desc: prometheus.NewDesc(
-				"runtime_memory_heap_allocated_bytes",
-				"Heap bytes allocated and still in use.",
-				nil, nil,
-			),
-			eval:    func(ms *runtime.MemStats) float64 { return float64(ms.HeapAlloc) },
-			valType: prometheus.GaugeValue,
-		},
-		{
-			desc: prometheus.NewDesc(
-				"runtime_gc_high_watermark_bytes",
-				"Next run in HeapAlloc time (bytes).",
-				nil, nil,
-			),
-			eval:    func(ms *runtime.MemStats) float64 { return float64(ms.NextGC) },
-			valType: prometheus.GaugeValue,
-		},
-		{
-			desc: prometheus.NewDesc(
-				"runtime_gc_pause_ns",
-				"Total GC pause time.",
-				nil, nil,
-			),
-			eval:    func(ms *runtime.MemStats) float64 { return float64(ms.PauseTotalNs) },
-			valType: prometheus.GaugeValue,
-		},
-		{
-			desc: prometheus.NewDesc(
-				"runtime_gc_total",
-				"Total number of GC runs.",
-				nil, nil,
-			),
-			eval:    func(ms *runtime.MemStats) float64 { return float64(ms.NumGC) },
-			valType: prometheus.CounterValue,
-		},
-	}
 )
-
-type internalMetrics []struct {
-	desc    *prometheus.Desc
-	eval    func(*runtime.MemStats) float64
-	valType prometheus.ValueType
-}
-
-func (im internalMetrics) Describe(ch chan<- *prometheus.Desc) {
-	for _, i := range im {
-		ch <- i.desc
-	}
-}
-
-func (im internalMetrics) Collect(ch chan<- prometheus.Metric) {
-	memStats := &runtime.MemStats{}
-	runtime.ReadMemStats(memStats)
-	for _, i := range im {
-		ch <- prometheus.MustNewConstMetric(i.desc, i.valType, i.eval(memStats))
-	}
-}
 
 func main() {
 	flag.Parse()
@@ -136,8 +48,6 @@ func main() {
 
 	ms := storage.NewDiskMetricStore(*persistenceFile, *persistenceInterval)
 	prometheus.SetMetricFamilyInjectionHook(ms.GetMetricFamilies)
-
-	prometheus.MustRegister(im)
 
 	r := httprouter.New()
 	r.Handler("GET", *metricsPath, prometheus.Handler())


### PR DESCRIPTION
With current versions of client_golang, internal metrics are
automatically exported by the client library. (In fact, not all mem
stats are included yet, but that will be added eventually. See
https://github.com/prometheus/client_golang/issues/96 .)

@juliusv 