### PR TITLE
Rename ext to pbutil

### DIFF
--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -15,13 +15,13 @@ package handler
 
 import (
 	"bytes"
+	"code.google.com/p/goprotobuf/proto"
+	"github.com/julienschmidt/httprouter"
+	"github.com/matttproud/golang_protobuf_extensions/pbutil"
+	dto "github.com/prometheus/client_model/go"
 	"net/http"
 	"net/http/httptest"
 	"testing"
-	"code.google.com/p/goprotobuf/proto"
-	"github.com/julienschmidt/httprouter"
-	"github.com/matttproud/golang_protobuf_extensions/ext"
-	dto "github.com/prometheus/client_model/go"
 
 	"github.com/prometheus/pushgateway/storage"
 )
@@ -183,7 +183,7 @@ another_metric{instance="baz"} 42
 	// With job name and instance name and protobuf content.
 	mms.lastWriteRequest = storage.WriteRequest{}
 	buf := &bytes.Buffer{}
-	_, err = ext.WriteDelimited(buf, &dto.MetricFamily{
+	_, err = pbutil.WriteDelimited(buf, &dto.MetricFamily{
 		Name: proto.String("some_metric"),
 		Type: dto.MetricType_UNTYPED.Enum(),
 		Metric: []*dto.Metric{
@@ -198,7 +198,7 @@ another_metric{instance="baz"} 42
 		t.Fatal(err)
 	}
 
-	_, err = ext.WriteDelimited(buf, &dto.MetricFamily{
+	_, err = pbutil.WriteDelimited(buf, &dto.MetricFamily{
 		Name: proto.String("another_metric"),
 		Type: dto.MetricType_UNTYPED.Enum(),
 		Metric: []*dto.Metric{

--- a/handler/push.go
+++ b/handler/push.go
@@ -23,7 +23,7 @@ import (
 
 	"code.google.com/p/goprotobuf/proto"
 	"github.com/julienschmidt/httprouter"
-	"github.com/matttproud/golang_protobuf_extensions/ext"
+	"github.com/matttproud/golang_protobuf_extensions/pbutil"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/text"
 
@@ -76,7 +76,7 @@ func Push(ms storage.MetricStore, replace bool) func(http.ResponseWriter, *http.
 				metricFamilies = map[string]*dto.MetricFamily{}
 				for {
 					mf := &dto.MetricFamily{}
-					if _, err = ext.ReadDelimited(r.Body, mf); err != nil {
+					if _, err = pbutil.ReadDelimited(r.Body, mf); err != nil {
 						if err == io.EOF {
 							err = nil
 						}

--- a/storage/diskmetricstore.go
+++ b/storage/diskmetricstore.go
@@ -335,7 +335,7 @@ func (dms *DiskMetricStore) restore() error {
 
 func writeTimestampedMetricFamily(e *gob.Encoder, tmf TimestampedMetricFamily) error {
 	// Since we have to serialize the timestamp, too, we are using gob for
-	// everything (and not ext.WriteDelimited).
+	// everything (and not pbutil.WriteDelimited).
 	buffer, err := proto.Marshal(tmf.MetricFamily)
 	if err != nil {
 		return err


### PR DESCRIPTION
This commit is related to upstream golang_protobuf_extensions:

- Swap ext for pbutil because old name was bad.
- https://github.com/matttproud/golang_protobuf_extensions/commit/d23aa0353c6500a97c053615ebd6dcb694d56cc1

@beorn7