### PR TITLE
Never honor GOBIN and let the GOBIN path set automatically

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,8 @@ GOCC   := $(GOROOT)/bin/go
 GOLIB  := $(GOROOT)/pkg/$(GOOS)_$(GOARCH)
 GO     := GOROOT=$(GOROOT) GOPATH=$(GOPATH) $(GOCC)
 
+unexport GOBIN
+
 SUFFIX  := $(GOOS)-$(GOARCH)
 BINARY  := bin/$(TARGET)
 ARCHIVE := $(TARGET)-$(VERSION).$(SUFFIX).tar.gz


### PR DESCRIPTION
This attempts to fix https://github.com/prometheus/pushgateway/issues/37

In my environment I had $GOBIN set, this confused the makefile into installing the go-bindata binary into the wrong path. Unsetting the $GOBIN variable lets the build complete in a more reliable way.