### PR TITLE
New Dockerfile using alpine-golang-make-onbuild base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM       ubuntu
-MAINTAINER The Prometheus Authors <prometheus-developers@googlegroups.com>
-EXPOSE     9091
+FROM        sdurrheimer/alpine-golang-make-onbuild
+MAINTAINER  The Prometheus Authors <prometheus-developers@googlegroups.com>
 
-RUN        apt-get -qy update && apt-get install -yq make git curl sudo mercurial gcc
+USER root
+RUN  mkdir /pushgateway \
+     && chown golang:golang /pushgateway
 
-ADD        . /pushgateway
-WORKDIR    /pushgateway
-RUN        make
-ENTRYPOINT [ "/pushgateway/pushgateway" ]
+USER        golang
+WORKDIR     /pushgateway
+EXPOSE      9091

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ used for service-level metrics.
 Compile the binary using the provided Makefile (type `make`).
 
 For the most basic setup, just start the binary. To change the address
-to listen on, use the `-addr` flag. The `-persistence.file` flag
+to listen on, use the `-web.listen-address` flag. The `-persistence.file` flag
 allows you to specify a file in which the pushed metrics will be
 persisted (so that they survive restarts of the Pushgateway).
 
@@ -125,7 +125,7 @@ You can still force Prometheus to attach a different timestamp by
 using the optional timestamp field in the exchange format. However,
 there are very few use cases where that would make
 sense. (Essentially, if you push more often than every 5min, you
-could attach the time of pushing as a timestamp.) 
+could attach the time of pushing as a timestamp.)
 
 ## API
 
@@ -260,3 +260,15 @@ Comments](https://code.google.com/p/go-wiki/wiki/CodeReviewComments)
 and the _Formatting and style_ section of Peter Bourgon's [Go:
 Best Practices for Production
 Environments](http://peter.bourgon.org/go-in-production/#formatting-and-style).
+
+## Using Docker
+
+You can deploy the Pushgateway using the [prom/pushgateway](https://registry.hub.docker.com/u/prom/pushgateway/) Docker image.
+
+For example:
+
+```bash
+docker pull prom/pushgateway
+
+docker run -d -p 9091:9091 prom/pushgateway
+```


### PR DESCRIPTION
Following the docker related PR series.

New Dockerfile using the [alpine-golang-make-onbuild](https://github.com/sdurrheimer/alpine-golang-make-onbuild) base image whose goal is to unified the way to dockerize prometheus tools and exporters based on Golang.

The binary is build using make. (Golang is installed via make too, respecting the GO_VERSION).

A testable image is available under my name on Docker hub : [Link](https://registry.hub.docker.com/u/sdurrheimer/pushgateway/)

I have also added some Docker usage instructions in the readme.

As always, the [alpine-golang-make-onbuild](https://github.com/sdurrheimer/alpine-golang-make-onbuild)  image can be also move under Prometheus organization.

@beorn7 @discordianfish 