### PR TITLE
Fix lint warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,11 +19,11 @@ BRANCH     := $(shell git rev-parse --abbrev-ref HEAD 2> /dev/null  || echo 'unk
 HOSTNAME   := $(shell hostname -f)
 BUILD_DATE := $(shell date +%Y%m%d-%H:%M:%S)
 GOFLAGS := -ldflags \
-        "-X main.buildVersion $(VERSION)\
-         -X main.buildRev $(REV)\
-         -X main.buildBranch $(BRANCH)\
-         -X main.buildUser $(USER)@$(HOSTNAME)\
-         -X main.buildDate $(BUILD_DATE)"
+        "-X main.buildVersion=$(VERSION)\
+         -X main.buildRev=$(REV)\
+         -X main.buildBranch=$(BRANCH)\
+         -X main.buildUser=$(USER)@$(HOSTNAME)\
+         -X main.buildDate=$(BUILD_DATE)"
 
 include Makefile.COMMON
 


### PR DESCRIPTION
Fix these:
link: warning: option -X main.buildVersion 0.2.0 may not work in future releases; use -X main.buildVersion=0.2.0
link: warning: option -X main.buildRev 9647eef may not work in future releases; use -X main.buildRev=9647eef
...