### PR TITLE
Push should reject requests with improper labels.

### DIFF
--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -401,3 +401,36 @@ func TestDelete(t *testing.T) {
 		t.Errorf("Wanted instance %v, got %v.", expected, got)
 	}
 }
+
+func TestSplitLabels(t *testing.T) {
+	proper_labels := "/label_name1/label_value1/label_name2/label_value2"
+	expected_parsed := map[string]string{
+		"label_name1": "label_value1",
+		"label_name2": "label_value2",
+	}
+	parsed, err := splitLabels(proper_labels)
+	if err != nil {
+		t.Errorf("Got unexpected error: %s.", err)
+	}
+	for k, v := range expected_parsed {
+		got, ok := parsed[k]
+		if !ok {
+			t.Errorf("Expected to find key %s.", k)
+		}
+		if got != v {
+			t.Errorf("Expected %s but got %s.", v, got)
+		}
+	}
+
+	improper_labels := "/label_name1/label_value1/a=b/label_value2"
+	_, err = splitLabels(improper_labels)
+	if err == nil {
+		t.Error("Expected splitLabels to return an error when given improper labels.")
+	}
+
+	reserved_labels := "/label_name1/label_value1/__label_name2/label_value2"
+	_, err = splitLabels(reserved_labels)
+	if err == nil {
+		t.Error("Expected splitLabels to return an error when given a reserved label.")
+	}
+}

--- a/handler/push.go
+++ b/handler/push.go
@@ -265,7 +265,12 @@ func splitLabels(labels string) (map[string]string, error) {
 	if len(components)%2 != 0 {
 		return nil, fmt.Errorf("odd number of components in label string %q", labels)
 	}
+
 	for i := 0; i < len(components)-1; i += 2 {
+		if !model.LabelNameRE.MatchString(components[i]) ||
+			strings.HasPrefix(components[i], model.ReservedLabelPrefix) {
+			return nil, fmt.Errorf("improper label name %q", components[i])
+		}
 		result[components[i]] = components[i+1]
 	}
 	return result, nil


### PR DESCRIPTION
prometheus/pushgateway/issues/54 explains a bug where a labelname of `a=b` was not rejected by pushgateway.

The current iteration of this patch checks all labelnames against the official regex provided in the documentation: `[a-zA-Z_][a-zA-Z0-9_]*`. It comes with a test to confirm `splitLabels` is functioning correctly.

@grobie mentioned in irc that returning a `4xx` would be a good solution. He also mentioned that it would be good to increment some kind of error metric when this error was encountered. I'm not sure what he means by the latter statement.

This would be my first attempt at a patch to Prometheus. Please state frankly if this is more of a burden then of help.