### PR TITLE
Reject pushes with timestamps.

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,8 +87,6 @@ Examples:
         cat <<EOF | curl --data-binary @- http://pushgateway.example.org:9091/metrics/job/some_job/instance/some_instance
         # TYPE some_metric counter
         some_metric{label="val1"} 42
-        # This one even has a timestamp (but beware, see below).
-        some_metric{label="val2"} 34 1398355504000
         # TYPE another_metric gauge
         # HELP another_metric Just an example.
         another_metric 2398.283
@@ -157,11 +155,12 @@ be scraped at all anymore. (Prometheus knows only one timestamp per
 sample, there is no way to distinguish a 'time of pushing' and a 'time
 of scraping'.)
 
-You can still force Prometheus to attach a different timestamp by
-using the optional timestamp field in the exchange format. However,
-there are very few use cases where that would make
-sense. (Essentially, if you push more often than every 5min, you
-could attach the time of pushing as a timestamp.)
+As there are essentially no use cases where it would make sense to to attach a
+different timestamp, and many users attempting to incorrectly do so (despite no
+client library supporting this) any pushes with timestamps will be rejected.
+
+If you think you need to push a timestamp, please see [When To Use The
+Pushgateway](https://prometheus.io/docs/practices/pushing/).
 
 ## API
 


### PR DESCRIPTION
Fixes #109

I once thought that some day we'd solve staleness, and there
would be valid use cases for the pushgateway to expose timestamps.
With the recent work on staleness this has turned out not to be the case.
As every single person we have seen pushing timestamps to the pgw
has been doing so incorrectly (usually misguidedly trying to make
Prometheus do push), let's send a stronger signal that this is not the
right way to do things.

With this in place I think we'll have all the mitigation we're going to
get in terms of discourage users from misusing timestamps, and it'll be
tolerable to add timestamp support to client libraries for the very very
few use cases that need this advanced feature (at current count:
collectd, cloudwatch, graphite and inflxudb exporters).

This should in principle have no impact as a) there is no documentation
saying that this is a good idea or even an idea and b) there is no code
support in our libraries for pushing timestamps.

@beorn7 @fabxc @juliusv 

https://github.com/prometheus/prometheus/issues/398 is going to be resolved very soon. I've always said that staleness blocked adding timestamps to clients due to repeated abuse by users via the pgw (despite us not offering any library support for such abuse), however it turns out staleness handling doesn't help. So let's do this instead to discourage the primary method of abuse, and once this is released we can unblock client library timestamps.