### PR TITLE
Add push_time_seconds for when the last push was.

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ time. A metric that cannot be scraped has basically ceased to
 exist. Prometheus is somewhat tolerant, but if it cannot get any
 samples for a metric in 5min, it will behave as if that metric does
 not exist anymore. Preventing that is actually one of the reasons to
-use a push gateway. The push gateway will make the metrics of your
+use a Pushgateway. The Pushgateway will make the metrics of your
 ephemeral job scrapable at any time. Attaching the time of pushing as
 a timestamp would defeat that purpose because 5min after the last
 push, your metric will look as stale to Prometheus as if it could not
@@ -161,6 +161,11 @@ client library supporting this) any pushes with timestamps will be rejected.
 
 If you think you need to push a timestamp, please see [When To Use The
 Pushgateway](https://prometheus.io/docs/practices/pushing/).
+
+In order to make it easier to alert on pushers that have not run recently, the
+Pushgateway will add in a metric `push_time_seconds` with the Unix timestamp
+of the last `POST`/`PUT` to each group. This will override any pushed metric by
+that name.
 
 ## API
 

--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -159,6 +159,9 @@ func TestPush(t *testing.T) {
 	if expected, got := `name:"another_metric" type:UNTYPED metric:<label:<name:"instance" value:"testinstance" > label:<name:"job" value:"testjob" > untyped:<value:42 > > `, mms.lastWriteRequest.MetricFamilies["another_metric"].String(); expected != got {
 		t.Errorf("Wanted metric family %v, got %v.", expected, got)
 	}
+	if _, ok := mms.lastWriteRequest.MetricFamilies["push_time_seconds"]; !ok {
+		t.Errorf("Wanted metric family push_time_seconds missing.")
+	}
 
 	// With job name and no instance name and text content.
 	mms.lastWriteRequest = storage.WriteRequest{}
@@ -253,6 +256,9 @@ func TestPush(t *testing.T) {
 	}
 	if expected, got := `name:"another_metric" type:UNTYPED metric:<label:<name:"instance" value:"testinstance" > label:<name:"job" value:"testjob" > untyped:<value:42 > > `, mms.lastWriteRequest.MetricFamilies["another_metric"].String(); expected != got {
 		t.Errorf("Wanted metric family %v, got %v.", expected, got)
+	}
+	if _, ok := mms.lastWriteRequest.MetricFamilies["push_time_seconds"]; !ok {
+		t.Errorf("Wanted metric family push_time_seconds missing.")
 	}
 
 	// With job name and instance name and timestamp, legacy handler.


### PR DESCRIPTION
Fixes #108 

@beorn7 

I'm not fully happy with the metric name, but it is consistent with what's already in the UI - we don't currently distinguish between push and pushadd there.