### PR TITLE
Dockerfile updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
 FROM        quay.io/prometheus/busybox:latest
-MAINTAINER  The Prometheus Authors <prometheus-developers@googlegroups.com>
+LABEL maintainer "The Prometheus Authors <prometheus-developers@googlegroups.com>"
 
 COPY pushgateway /bin/pushgateway
 
 EXPOSE     9091
+RUN mkdir -p /pushgateway
 WORKDIR    /pushgateway
 ENTRYPOINT [ "/bin/pushgateway" ]


### PR DESCRIPTION
Fixes #106 by `mkdir`ing the `/pushgateway` for container runtimes which may not create it the `WORKDIR` automatically.

I've also replaced the [deprecated `MAINTAINER`](https://docs.docker.com/engine/reference/builder/#maintainer-deprecated) instruction with a `LABEL`, to match https://github.com/prometheus/prometheus/blob/master/Dockerfile#L2

Signed-off-by: Dave Henderson <dhenderson@gmail.com>