### PR TITLE
Added example for option 'web.listen-address'

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ If you want to compile yourself from the sources, you need a working Go
 setup. Then use the provided Makefile (type `make`).
 
 For the most basic setup, just start the binary. To change the address
-to listen on, use the `-web.listen-address` flag. By default, Pushgateway 
+to listen on, use the `-web.listen-address` flag (ie "0.0.0.0:9090"). By default, Pushgateway
 does not persist metrics. However, the `-persistence.file` flag
 allows you to specify a file in which the pushed metrics will be
 persisted (so that they survive restarts of the Pushgateway).

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ If you want to compile yourself from the sources, you need a working Go
 setup. Then use the provided Makefile (type `make`).
 
 For the most basic setup, just start the binary. To change the address
-to listen on, use the `-web.listen-address` flag (i.e. "0.0.0.0:9091" or ":9091").
+to listen on, use the `-web.listen-address` flag (e.g. "0.0.0.0:9091" or ":9091").
 By default, Pushgateway does not persist metrics. However, the `-persistence.file` flag
 allows you to specify a file in which the pushed metrics will be
 persisted (so that they survive restarts of the Pushgateway).

--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ If you want to compile yourself from the sources, you need a working Go
 setup. Then use the provided Makefile (type `make`).
 
 For the most basic setup, just start the binary. To change the address
-to listen on, use the `-web.listen-address` flag (ie "0.0.0.0:9091" or ":9091"). By default, Pushgateway
-does not persist metrics. However, the `-persistence.file` flag
+to listen on, use the `-web.listen-address` flag (i.e. "0.0.0.0:9091" or ":9091").
+By default, Pushgateway does not persist metrics. However, the `-persistence.file` flag
 allows you to specify a file in which the pushed metrics will be
 persisted (so that they survive restarts of the Pushgateway).
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ If you want to compile yourself from the sources, you need a working Go
 setup. Then use the provided Makefile (type `make`).
 
 For the most basic setup, just start the binary. To change the address
-to listen on, use the `-web.listen-address` flag (ie "0.0.0.0:9090"). By default, Pushgateway
+to listen on, use the `-web.listen-address` flag (ie "0.0.0.0:9091" or ":9091"). By default, Pushgateway
 does not persist metrics. However, the `-persistence.file` flag
 allows you to specify a file in which the pushed metrics will be
 persisted (so that they survive restarts of the Pushgateway).


### PR DESCRIPTION
it's not intuitive you need to use the format "IP:PORT", for example this invocation:

`docker run -ti prom/pushgateway -web.listen-address 8080`

produce a misleading error:

`INFO[0000] Starting pushgateway (version=0.4.0, branch=master, revision=6ceb4a19fa85ac2d6c2d386c144566fb1ede1f6c)  source=main.go:57
INFO[0000] Build context (go=go1.8.3, user=root@87741d1b66a9, date=20170609-12:25:40)  source=main.go:58
INFO[0000] Listening on 8080.                            source=main.go:102
FATA[0000] listen tcp: address 8080: missing port in address  source=main.go:105`