### PR TITLE
Add documentation about TTL and GH issues

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,56 @@
+<!--
+
+	Note that we use GitHub issues for bugs and (uncontroversial) feature
+    requests (see below for details).
+
+    Please do *NOT* ask usage questions in GitHub issues.  Usage questions make
+	most sense on the users mailing list, where more people are available to
+	potentially respond to your question, and the whole community can benefit
+	from the answers provided (perhaps your question has already been answered,
+	search the archive to find out):
+	https://groups.google.com/forum/#!forum/prometheus-users
+
+	While a GitHub issue is fine to track progress on an uncontroversial
+	feature request, many feature requests touch the best practices and
+	concepts of Prometheus as a whole and need to be discussed with the wider
+	developer community first. This is in particular true for a request to
+	reconsider a prior rejection of a feature request or any of the declared
+	non-goals (see README.md). Those overarching discussions happen on the
+	developer mailing list (GitHub issues, in particular closed ones, are not
+	tracked by the wider developer community and thus inadequate):
+	https://groups.google.com/forum/#!forum/prometheus-developers
+	
+    You can find more information at: https://prometheus.io/community/
+
+-->
+
+## Feature request
+**Use case. Why is this important?**
+
+*“Nice to have” is not a good use case. :)*
+
+## Bug Report
+**What did you do?**
+
+**What did you expect to see?**
+
+**What did you see instead? Under which circumstances?**
+
+**Environment**
+
+* System information:
+
+		Insert output of `uname -srm` here.
+
+* Pushgateway version:
+
+		Insert output of `pushgateway --version` here.
+
+* Pushgateway command line:
+
+		Insert full command line.
+
+* Logs:
+```
+Insert Pushgateway logs relevant to the issue here.
+```

--- a/README.md
+++ b/README.md
@@ -29,6 +29,11 @@ source for
 [Grafana annotations](http://docs.grafana.org/reference/annotations/), tracking
 something like release events has to happen with some event-logging framework.
 
+A while ago, we
+[decided to not implement a “timeout” or TTL for pushed metrics](https://github.com/prometheus/pushgateway/issues/19)
+because almost all proposed use cases turned out to be anti-patterns we
+strongly discourage.
+
 ## Run it
 
 Download binary releases for your platform from the


### PR DESCRIPTION
- Add an issue template similar to other repos.
- Add TTL for metrics as a non-goal.

@juliusv inspired by yet another follow-up to closed https://github.com/prometheus/pushgateway/issues/19

Signed-off-by: beorn7 <beorn@soundcloud.com>