### PR TITLE
circleci: switch to 2.1 config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,12 +1,11 @@
 ---
-version: 2
+version: 2.1
 
 jobs:
   test:
     docker:
     - image: circleci/golang:1.11
     working_directory: /go/src/github.com/prometheus/pushgateway
-    resource_class: large
 
     steps:
     - checkout


### PR DESCRIPTION
Similar to https://github.com/prometheus/prometheus/pull/4713 and https://github.com/prometheus/alertmanager/pull/1579. Once the 2.1 config is enabled, we can reduce duplication in `.circleci/config.yml` a bit.