### PR TITLE
Add command-line option to clear all metrics after scrape requests

### DIFF
--- a/storage/diskmetricstore.go
+++ b/storage/diskmetricstore.go
@@ -176,6 +176,13 @@ func (dms *DiskMetricStore) Ready() error {
 	return dms.Healthy()
 }
 
+func (dms *DiskMetricStore) Clear() {
+	dms.lock.Lock()
+	defer dms.lock.Unlock()
+
+	dms.metricGroups = GroupingKeyToMetricGroup{}
+}
+
 func (dms *DiskMetricStore) loop(persistenceInterval time.Duration) {
 	lastPersist := time.Now()
 	persistScheduled := false


### PR DESCRIPTION
Having read mailing list discussions (as well as the `README.md`) on various pros/cons of TTL-like features, I have implemented a command-line option for a _non-TTL-based_ immediate clearing of all existing metrics accumulated in the push gateway right after every scrape request.

We needed this for our own purposes and if the maintainers find that it falls on the non-controversial side of the TTL-related discussion, please feel free to merge it. Philosophically, this implementation is not _that_ different than using the `textfile` collector and blanking the text file every time a `GET /metrics` request is observed via a potential proxy sitting in front of `node_exporter`, so I don't think it's enabling a usage that's not otherwise possible by combining a few components...