### PR TITLE
Add command-line option to track scrape requesters for each metric

### DIFF
--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -35,7 +35,7 @@ func (m *MockMetricStore) SubmitWriteRequest(req storage.WriteRequest) {
 	m.lastWriteRequest = req
 }
 
-func (m *MockMetricStore) GetMetricFamilies() []*dto.MetricFamily {
+func (m *MockMetricStore) GetMetricFamilies(querier string) []*dto.MetricFamily {
 	panic("not implemented")
 }
 

--- a/storage/diskmetricstore_test.go
+++ b/storage/diskmetricstore_test.go
@@ -809,7 +809,7 @@ func TestHelpStringFix(t *testing.T) {
 	time.Sleep(20 * time.Millisecond) // Give loop() time to process.
 
 	// Either we have settle on the mfh1 help string or the mfh2 help string.
-	gotMFs := dms.GetMetricFamilies()
+	gotMFs := dms.GetMetricFamilies("")
 	if len(gotMFs) != 2 {
 		t.Fatalf("expected 2 metric families, got %d", len(gotMFs))
 	}
@@ -845,7 +845,7 @@ func TestHelpStringFix(t *testing.T) {
 }
 
 func checkMetricFamilies(dms *DiskMetricStore, expectedMFs ...*dto.MetricFamily) error {
-	gotMFs := dms.GetMetricFamilies()
+	gotMFs := dms.GetMetricFamilies("")
 	if expected, got := len(expectedMFs), len(gotMFs); expected != got {
 		return fmt.Errorf("expected %d metric families, got %d", expected, got)
 	}

--- a/storage/interface.go
+++ b/storage/interface.go
@@ -38,7 +38,7 @@ type MetricStore interface {
 	// Metrics. Inconsistent help strings or types are logged, and one of
 	// the versions will "win". Inconsistent and duplicate label sets will
 	// go undetected.
-	GetMetricFamilies() []*dto.MetricFamily
+	GetMetricFamilies(querier string) []*dto.MetricFamily
 	// GetMetricFamiliesMap returns a map grouping-key -> MetricGroup. The
 	// MetricFamily pointed to by the Metrics map in each MetricGroup is
 	// guaranteed to not be modified by the MetricStore anymore. However,
@@ -116,6 +116,7 @@ type NameToTimestampedMetricFamilyMap map[string]TimestampedMetricFamily
 type TimestampedMetricFamily struct {
 	Timestamp            time.Time
 	GobbableMetricFamily *GobbableMetricFamily
+	Queriers             map[string]struct{}
 }
 
 // GetMetricFamily returns the normal GetMetricFamily DTO (without the gob additions).


### PR DESCRIPTION
This is a follow-up to https://github.com/prometheus/pushgateway/pull/235 and while I understand that @beorn7 may indeed make the same final judgment, his comments did make me alter my implementation a bit to track the scrape requesters for each metric separately and implement the "one shot" propagation of every metric on a per-requester (at the IP address level) basis. This allows the `pushgateway`, when launched with the `--web.scrape-once` option, to "hide" each metric from a given scraper that has already scraped it _until_ that metric is pushed again. This addresses the concerns raised in https://github.com/prometheus/pushgateway/pull/235 related to HA-like scenarios whereby it is desirable for the presence of any number of scrapers to not affect the propagation of metrics to other scrapers. It also leaves the on-disk persistence behavior of `pushgateway` unaltered.

tl;dr @beorn7 thank you for your earlier feedback and I won't be offended if you close this PR as well, but it seemed amiss not to submit the revision at this point.