### PR TITLE
Run process as non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,12 @@
 FROM quay.io/prometheus/busybox:latest
 LABEL maintainer="The Prometheus Authors <prometheus-developers@googlegroups.com>"
 
-COPY pushgateway /bin/pushgateway
+COPY --chown=nobody:nogroup pushgateway /bin/pushgateway
 
 EXPOSE 9091
-RUN mkdir -p /pushgateway
+RUN mkdir -p /pushgateway && chown nobody:nogroup /pushgateway
 WORKDIR /pushgateway
+
+USER 65534
+
 ENTRYPOINT [ "/bin/pushgateway" ]


### PR DESCRIPTION
A process should not run as root in a container if not explicitly required. Therefore, added a pushgateway user with user id 1000 and set
the user to 1000. This should be compatible with k8s PSP's which check
for the user id.