### PR TITLE
Replace `path.Join` by normal string concatenation

### DIFF
--- a/handler/status.go
+++ b/handler/status.go
@@ -19,7 +19,6 @@ import (
 	"html/template"
 	"io/ioutil"
 	"net/http"
-	"path"
 	"strconv"
 	"time"
 
@@ -71,7 +70,10 @@ func Status(
 
 			externalURL := flags["web.external-url"]
 			routePrefix := flags["web.route-prefix"]
-			baseURL := path.Join(externalURL, routePrefix)
+			// At this point, externalURL has no path and
+			// routePrefix is either empty or starts, but does not
+			// end, with a '/'.
+			baseURL := externalURL + routePrefix
 
 			f, err := root.Open("template.html")
 			if err != nil {


### PR DESCRIPTION
`path.Join` cleans up all double-slashes anh thus wreaks havoc with a
URL. The plain string concatenation is actually fine here as all the
sanitations have already happened.

This is a fix for the [fix](#239) of #190.

@apghero @sepich