### PR TITLE
 Add the option to base64-encode label names in push URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,24 +211,24 @@ All pushes are done via HTTP. The interface is vaguely REST-like.
 
 The default port the push gateway is listening to is 9091. The path looks like
 
-    /metrics/job/<JOBNAME>{/<LABEL_NAME>/<LABEL_VALUE>}
+    /metrics/job/<JOB_NAME>{/<LABEL_NAME>/<LABEL_VALUE>}
 
-`<JOBNAME>` is used as the value of the `job` label, followed by any
+`<JOB_NAME>` is used as the value of the `job` label, followed by any
 number of other label pairs (which might or might not include an
 `instance` label). The label set defined by the URL path is used as a
 grouping key. Any of those labels already set in the body of the
 request (as regular labels, e.g. `name{job="foo"} 42`)
 _will be overwritten to match the labels defined by the URL path!_
 
-If the job name or any label value starts with a `=`, the remaining part is
-interpreted as a base64 encoded string according to [RFC 4648, using the URL
-and filename safe
+If `job` or any label name is suffixed with `@base64`, the following job name
+or label value is interpreted as a base64 encoded string according to [RFC
+4648, using the URL and filename safe
 alphabet](https://tools.ietf.org/html/rfc4648#section-5). (Padding is
 optional.) This is the only way of using job names or label values that contain
-a `/` or start with a `=`. For other special characters, the usual URI
-component encoding works, too, but the base64 might be more convenient.
+a `/`. For other special characters, the usual URI component encoding works,
+too, but the base64 might be more convenient.
 
-Ideally, client libraries take care of this encoding.
+Ideally, client libraries take care of the suffixing and encoding.
 
 Examples:
 
@@ -237,18 +237,17 @@ Examples:
 
 	  /metrics/job/directory_cleaner/path//var/tmp
 	  
-  Instead, use the base64 URL-safe encoding with a leading `=`:
+  Instead, use the base64 URL-safe encoding for the label value and mark it by
+  suffixing the label name with `@base64`:
   
-  	  /metrics/job/directory_cleaner/path/=L3Zhci90bXA
+  	  /metrics/job/directory_cleaner/path@base64/L3Zhci90bXA
 	  
   If you are not using a client library that handles the encoding for you, you
   can use encoding tools. For example, there is a command line tool `base64url`
   (Debian package `basez`), which you could combine with `curl` to push from
   the command line in the following way:
   
-      echo 'some_metric{foo="bar"} 3.14' | curl --data-binary @- http://pushgateway.example.org:9091/metrics/job/directory_cleaner/path/=$(echo -n '/var/tmp' | base64url)
- 
-  Note the leading `=`.
+      echo 'some_metric{foo="bar"} 3.14' | curl --data-binary @- http://pushgateway.example.org:9091/metrics/job/directory_cleaner/path@base64/$(echo -n '/var/tmp' | base64url)
   
 * The grouping key `job="titan",name="Προμηθεύς"` can be represented
   “traditionally” with URI encoding:
@@ -257,7 +256,7 @@ Examples:
 	  
   Or you can use the more compact base64 encoding:
   
-      /metrics/job/titan/name/=zqDPgc6_zrzOt864zrXPjc-C
+      /metrics/job/titan/name@base64/zqDPgc6_zrzOt864zrXPjc-C
 
 ### `PUT` method
 

--- a/README.md
+++ b/README.md
@@ -220,10 +220,44 @@ grouping key. Any of those labels already set in the body of the
 request (as regular labels, e.g. `name{job="foo"} 42`)
 _will be overwritten to match the labels defined by the URL path!_
 
-Note that `/` cannot be used as part of a label value or the job name,
-even if escaped as `%2F`. (The decoding happens before the path
-routing kicks in, cf. the Go documentation of
-[`URL.Path`](http://golang.org/pkg/net/url/#URL).)
+If the job name or any label value starts with a `=`, the remaining part is
+interpreted as a base64 encoded string according to [RFC 4648, using the URL
+and filename safe
+alphabet](https://tools.ietf.org/html/rfc4648#section-5). (Padding is
+optional.) This is the only way of using job names or label values that contain
+a `/` or start with a `=`. For other special characters, the usual URI
+component encoding works, too, but the base64 might be more convenient.
+
+Ideally, client libraries take care of this encoding.
+
+Examples:
+
+* To use the grouping key `job="directory_cleaner",path="/var/tmp"`, the
+  following path will _not_ work:
+
+	  /metrics/job/directory_cleaner/path//var/tmp
+	  
+  Instead, use the base64 URL-safe encoding with a leading `=`:
+  
+  	  /metrics/job/directory_cleaner/path/=L3Zhci90bXA
+	  
+  If you are not using a client library that handles the encoding for you, you
+  can use encoding tools. For example, there is a command line tool `base64url`
+  (Debian package `basez`), which you could combine with `curl` to push from
+  the command line in the following way:
+  
+      echo 'some_metric{foo="bar"} 3.14' | curl --data-binary @- http://pushgateway.example.org:9091/metrics/job/directory_cleaner/path/=$(echo -n '/var/tmp' | base64url)
+ 
+  Note the leading `=`.
+  
+* The grouping key `job="titan",name="Προμηθεύς"` can be represented
+  “traditionally” with URI encoding:
+  
+      /metrics/job/titan/name/%CE%A0%CF%81%CE%BF%CE%BC%CE%B7%CE%B8%CE%B5%CF%8D%CF%82
+	  
+  Or you can use the more compact base64 encoding:
+  
+      /metrics/job/titan/name/=zqDPgc6_zrzOt864zrXPjc-C
 
 ### `PUT` method
 

--- a/handler/push.go
+++ b/handler/push.go
@@ -42,6 +42,9 @@ import (
 const (
 	pushMetricName = "push_time_seconds"
 	pushMetricHelp = "Last Unix time when this group was changed in the Pushgateway."
+	// Base64Suffix is appended to a label name in the request URL path to
+	// mark the following label value as base64 encoded.
+	Base64Suffix = "@base64"
 )
 
 // Push returns an http.Handler which accepts samples over HTTP and stores them
@@ -50,17 +53,20 @@ const (
 //
 // The returned handler is already instrumented for Prometheus.
 func Push(
-	ms storage.MetricStore, replace bool, logger log.Logger,
+	ms storage.MetricStore, replace bool, jobBase64Encoded bool, logger log.Logger,
 ) func(http.ResponseWriter, *http.Request, httprouter.Params) {
 	var ps httprouter.Params
 	var mtx sync.Mutex // Protects ps.
 
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		job, err := maybeDecodeBase64(ps.ByName("job"))
-		if err != nil {
-			http.Error(w, fmt.Sprintf("invalid base64 encoding in job name %q: %v", ps.ByName("job"), err), http.StatusBadRequest)
-			level.Debug(logger).Log("msg", "invalid base64 encoding in job name", "job", ps.ByName("job"), "err", err.Error())
-			return
+		job := ps.ByName("job")
+		if jobBase64Encoded {
+			var err error
+			if job, err = decodeBase64(job); err != nil {
+				http.Error(w, fmt.Sprintf("invalid base64 encoding in job name %q: %v", ps.ByName("job"), err), http.StatusBadRequest)
+				level.Debug(logger).Log("msg", "invalid base64 encoding in job name", "job", ps.ByName("job"), "err", err.Error())
+				return
+			}
 		}
 		labelsString := ps.ByName("labels")
 		mtx.Unlock()
@@ -198,15 +204,11 @@ func sanitizeLabels(
 	}
 }
 
-// maybeDecodeBase64 returns s unchanged if it is empty or doesn't start with
-// '='. Otherwise, the leading '=' is trimmed and the remaining string is
-// decoded using the “Base 64 Encoding with URL and Filename Safe Alphabet” (RFC
-// 4648). Padding characters (i.e. trailing '=') are ignored.
-func maybeDecodeBase64(s string) (string, error) {
-	if len(s) == 0 || s[0] != '=' {
-		return s, nil
-	}
-	b, err := base64.RawURLEncoding.DecodeString(strings.TrimRight(s[1:], "="))
+// decodeBase64 decodes the provided string using the “Base 64 Encoding with URL
+// and Filename Safe Alphabet” (RFC 4648). Padding characters (i.e. trailing
+// '=') are ignored.
+func decodeBase64(s string) (string, error) {
+	b, err := base64.RawURLEncoding.DecodeString(strings.TrimRight(s, "="))
 	return string(b), err
 }
 
@@ -223,15 +225,20 @@ func splitLabels(labels string) (map[string]string, error) {
 
 	for i := 0; i < len(components)-1; i += 2 {
 		name, value := components[i], components[i+1]
-		if !model.LabelNameRE.MatchString(name) ||
-			strings.HasPrefix(name, model.ReservedLabelPrefix) {
-			return nil, fmt.Errorf("improper label name %q", name)
+		trimmedName := strings.TrimSuffix(name, Base64Suffix)
+		if !model.LabelNameRE.MatchString(trimmedName) ||
+			strings.HasPrefix(trimmedName, model.ReservedLabelPrefix) {
+			return nil, fmt.Errorf("improper label name %q", trimmedName)
 		}
-		decodedValue, err := maybeDecodeBase64(value)
+		if name == trimmedName {
+			result[name] = value
+			continue
+		}
+		decodedValue, err := decodeBase64(value)
 		if err != nil {
-			return nil, fmt.Errorf("invalid base64 encoding for label %s=%q: %v", name, value, err)
+			return nil, fmt.Errorf("invalid base64 encoding for label %s=%q: %v", trimmedName, value, err)
 		}
-		result[name] = decodedValue
+		result[trimmedName] = decodedValue
 	}
 	return result, nil
 }

--- a/handler/status.go
+++ b/handler/status.go
@@ -14,6 +14,7 @@
 package handler
 
 import (
+	"encoding/base64"
 	"fmt"
 	"html"
 	"html/template"
@@ -70,6 +71,9 @@ func Status(
 				},
 				"timeFormat": func(t time.Time) string {
 					return t.Format(time.RFC3339)
+				},
+				"base64": func(s string) string {
+					return base64.RawURLEncoding.EncodeToString([]byte(s))
 				},
 			})
 

--- a/main.go
+++ b/main.go
@@ -107,13 +107,15 @@ func main() {
 
 	// Handlers for pushing and deleting metrics.
 	pushAPIPath := *routePrefix + "/metrics"
-	r.PUT(pushAPIPath+"/job/:job/*labels", handler.Push(ms, true, logger))
-	r.POST(pushAPIPath+"/job/:job/*labels", handler.Push(ms, false, logger))
-	r.DELETE(pushAPIPath+"/job/:job/*labels", handler.Delete(ms, logger))
-	r.PUT(pushAPIPath+"/job/:job", handler.Push(ms, true, logger))
-	r.POST(pushAPIPath+"/job/:job", handler.Push(ms, false, logger))
-	r.DELETE(pushAPIPath+"/job/:job", handler.Delete(ms, logger))
-
+	for _, suffix := range []string{"", handler.Base64Suffix} {
+		jobBase64Encoded := suffix == handler.Base64Suffix
+		r.PUT(pushAPIPath+"/job"+suffix+"/:job/*labels", handler.Push(ms, true, jobBase64Encoded, logger))
+		r.POST(pushAPIPath+"/job"+suffix+"/:job/*labels", handler.Push(ms, false, jobBase64Encoded, logger))
+		r.DELETE(pushAPIPath+"/job"+suffix+"/:job/*labels", handler.Delete(ms, jobBase64Encoded, logger))
+		r.PUT(pushAPIPath+"/job"+suffix+"/:job", handler.Push(ms, true, jobBase64Encoded, logger))
+		r.POST(pushAPIPath+"/job"+suffix+"/:job", handler.Push(ms, false, jobBase64Encoded, logger))
+		r.DELETE(pushAPIPath+"/job"+suffix+"/:job", handler.Delete(ms, jobBase64Encoded, logger))
+	}
 	r.Handler("GET", *routePrefix+"/static/*filepath", handler.Static(asset.Assets, *routePrefix))
 
 	statusHandler := handler.Status(ms, asset.Assets, flags, logger)

--- a/resources/static/functions.js
+++ b/resources/static/functions.js
@@ -38,7 +38,7 @@ pushgateway.deleteGroup = function(){
     var pathElements = [];
     for (var ln in pushgateway.labels) {
 	if (ln != 'job') {
-	    pathElements.push(encodeURIComponent(ln));
+	    pathElements.push(encodeURIComponent(ln+'@base64'));
 	    pathElements.push(encodeURIComponent(pushgateway.labels[ln]));
 	}
     }
@@ -49,7 +49,7 @@ pushgateway.deleteGroup = function(){
     
     $.ajax({
 	type: 'DELETE',
-	url: 'metrics/job/' + encodeURIComponent(pushgateway.labels['job']) + groupPath,
+	url: 'metrics/job@base64/' + encodeURIComponent(pushgateway.labels['job']) + groupPath,
 	success: function(data, textStatus, jqXHR) {
 	    pushgateway.panel.remove();
 	    $('#del-modal').modal('hide');

--- a/resources/static/functions.js
+++ b/resources/static/functions.js
@@ -18,9 +18,9 @@ pushgateway.switchToStatus = function(){
     $('#status-li').addClass('active');
 }
 
-pushgateway.showDelModal = function(labels, panelID, event){
+pushgateway.showDelModal = function(labels, labelsEncoded, panelID, event){
     event.stopPropagation(); // Don't trigger accordion collapse.
-    pushgateway.labels = labels;
+    pushgateway.labels = labelsEncoded;
     pushgateway.panel = $('#' + panelID);
 
     var components = [];

--- a/resources/template.html
+++ b/resources/template.html
@@ -69,7 +69,7 @@ limitations under the License.
 	      <span class="badge {{if eq $ln "job"}}badge-warning{{else if eq $ln "instance"}}badge-primary{{else}}badge-info{{end}}">{{$ln}}="{{index $metricGroup.Labels $ln}}"</span>
 	    {{end}}
 	    </button>	     
-	    <button class="btn btn-xs btn-danger float-right" onclick="pushgateway.showDelModal({ {{range $i, $ln := .SortedLabels}}{{if $i}}, {{end}}'{{$ln}}': '{{index $metricGroup.Labels $ln}}'{{end}} }, 'group-panel-{{$gCount}}', event)">Delete Group</button>
+	    <button class="btn btn-xs btn-danger float-right" onclick="pushgateway.showDelModal({ {{range $i, $ln := .SortedLabels}}{{if $i}}, {{end}}'{{$ln}}': '{{index $metricGroup.Labels $ln}}'{{end}} }, { {{range $i, $ln := .SortedLabels}}{{if $i}}, {{end}}'{{$ln}}': '={{index $metricGroup.Labels $ln | base64}}'{{end}} }, 'group-panel-{{$gCount}}', event)">Delete Group</button>
 	  </h2>
 	</div>
 	<div id="j-{{$gCount}}" class="collapse" aria-labelledby="group-panel-{{$gCount}}" data-parent="#job-accordion">

--- a/resources/template.html
+++ b/resources/template.html
@@ -69,7 +69,7 @@ limitations under the License.
 	      <span class="badge {{if eq $ln "job"}}badge-warning{{else if eq $ln "instance"}}badge-primary{{else}}badge-info{{end}}">{{$ln}}="{{index $metricGroup.Labels $ln}}"</span>
 	    {{end}}
 	    </button>	     
-	    <button class="btn btn-xs btn-danger float-right" onclick="pushgateway.showDelModal({ {{range $i, $ln := .SortedLabels}}{{if $i}}, {{end}}'{{$ln}}': '{{index $metricGroup.Labels $ln}}'{{end}} }, { {{range $i, $ln := .SortedLabels}}{{if $i}}, {{end}}'{{$ln}}': '={{index $metricGroup.Labels $ln | base64}}'{{end}} }, 'group-panel-{{$gCount}}', event)">Delete Group</button>
+	    <button class="btn btn-xs btn-danger float-right" onclick="pushgateway.showDelModal({ {{range $i, $ln := .SortedLabels}}{{if $i}}, {{end}}'{{$ln}}': '{{index $metricGroup.Labels $ln}}'{{end}} }, { {{range $i, $ln := .SortedLabels}}{{if $i}}, {{end}}'{{$ln}}': '{{index $metricGroup.Labels $ln | base64}}'{{end}} }, 'group-panel-{{$gCount}}', event)">Delete Group</button>
 	  </h2>
 	</div>
 	<div id="j-{{$gCount}}" class="collapse" aria-labelledby="group-panel-{{$gCount}}" data-parent="#job-accordion">


### PR DESCRIPTION
This fixes #97.

I marked the maintainers of the official client libraries as reviewers, as you are most directly affected by this.

This still needs test added, but I want to get your thoughts first before writing them.

Copied from the commit description:

I did quite a lot of research about how to encode `/` in RESTful
request URLs. There doesn't seem to be a general consensus how to do
it (besides just not to do it). I found a few cases where systems
would accept base64 encoding (which has to be the "URL and Filename
safe" variant, otherwise you have `/` in there again, but at least the
existence of this variant in RFC 4648 tells us that it is kind of meant
for what we are doing here). But then the next problem arises: How to
mark what is base64 encoded and what is plain text? In most cases I
saw, the respective field is just marked as being always base64
encoded, which would be sad for our case as there are very few
situations where you actually need base64 encoding. One case used a
marker like `$base64:...`, which I found quite weird. However, I think
using some kind of marker is a good idea. I picked a leading `=` here
as that's a character that is rarely used as a first character of a
label value (and hopefully even less so for the label value in a
grouping key). It is also used in PGP to prefix a base64 encoded string.

I put details in the documentation (see README.md in this commit).

As illustrated there, a nice byproduct is that the encoding of special
characters is a bit saner now (imagine Chinese letters in label
values, which might be pretty common in, well, China).

As base64 encoding is readily available in standard libraries and even
as command line tools (again see examples in the documentation), I
think this is a pretty doable and not overly invasive way of dealing
with the problem.

Client libraries should of course support this encoding transparently.

The competition is mostly going away from the RESTful style and use
URL parameters. If we completely switch to it, we would break
everything hard. If we offered it as an alternative, we would deviate
from our best practice of only offering one way of doing one thing. It
would be a quite invasive change either way.

We could also use a custom escaping scheme just for the case of `/`,
but there is no precedent for that. We would have a solution only used
for the Pushgateway, and everyone had to implement that escaping
scheme on their own. (base64 is a more complex encoding, but the
tooling is readily available everywhere.)