### PR TITLE
Correctly remove the whole panel from the UI after deletion

### DIFF
--- a/resources/static/functions.js
+++ b/resources/static/functions.js
@@ -21,7 +21,7 @@ pushgateway.switchToStatus = function(){
 pushgateway.showDelModal = function(labels, labelsEncoded, panelID, event){
     event.stopPropagation(); // Don't trigger accordion collapse.
     pushgateway.labels = labelsEncoded;
-    pushgateway.panel = $('#' + panelID);
+    pushgateway.panel = $('#' + panelID).parent();
 
     var components = [];
     for (var ln in labels) {


### PR DESCRIPTION
The structure changed a lot due to the Bootstrap upgrade. Now we have
to delete one level up.

Fixes #270.

Signed-off-by: beorn7 <beorn@grafana.com>