### PR TITLE
Next attempt to make the --web.* flags work like in Prometheus

### DIFF
--- a/resources/template.html
+++ b/resources/template.html
@@ -19,15 +19,15 @@ limitations under the License.
     <meta name="robots" content="noindex,nofollow">
     <title>Prometheus Pushgateway</title>
 
-    <link rel="shortcut icon" href="{{.BaseURL}}/static/favicon.ico?v={{.BuildInfo.revision}}">
+    <link rel="shortcut icon" href="{{.PathPrefix}}/static/favicon.ico?v={{.BuildInfo.revision}}">
 
-    <script src="{{.BaseURL}}/static/jquery-3.4.1.min.js?v={{.BuildInfo.revision}}"></script>
-    <script src="{{.BaseURL}}/static/bootstrap-4.3.1-dist/js/bootstrap.min.js?v={{.BuildInfo.revision}}"></script>
-    <script src="{{.BaseURL}}/static/functions.js?v={{.BuildInfo.revision}}"></script>
+    <script src="{{.PathPrefix}}/static/jquery-3.4.1.min.js?v={{.BuildInfo.revision}}"></script>
+    <script src="{{.PathPrefix}}/static/bootstrap-4.3.1-dist/js/bootstrap.min.js?v={{.BuildInfo.revision}}"></script>
+    <script src="{{.PathPrefix}}/static/functions.js?v={{.BuildInfo.revision}}"></script>
 
-    <link type="text/css" rel="stylesheet" href="{{.BaseURL}}/static/bootstrap-4.3.1-dist/css/bootstrap.min.css?v={{.BuildInfo.revision}}">
-    <link type="text/css" rel="stylesheet" href="{{.BaseURL}}/static/prometheus.css?v={{.BuildInfo.revision}}">
-    <link type="text/css" rel="stylesheet" href="{{.BaseURL}}/static/bootstrap4-glyphicons/css/bootstrap-glyphicons.min.css?v={{.BuildInfo.revision}}">
+    <link type="text/css" rel="stylesheet" href="{{.PathPrefix}}/static/bootstrap-4.3.1-dist/css/bootstrap.min.css?v={{.BuildInfo.revision}}">
+    <link type="text/css" rel="stylesheet" href="{{.PathPrefix}}/static/prometheus.css?v={{.BuildInfo.revision}}">
+    <link type="text/css" rel="stylesheet" href="{{.PathPrefix}}/static/bootstrap4-glyphicons/css/bootstrap-glyphicons.min.css?v={{.BuildInfo.revision}}">
   </head>
 
   <body>


### PR DESCRIPTION
This also straightens out a few other things.

Note: I'm once more fairly convinced that we don't really need the `web.external-url` flag at all. We should be fine with just `web.route-prefix`. (But then the latter needed to be set in exactly the other case as for the Prometheus server. So perhaps we leave it as is to not confuse users. At some point, we might need `web.external-url` after all, for the same reasons Prometheus needs it.)