### PR TITLE
Document new Wipe admin-api-endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,10 @@ Examples:
   even if those metrics have the same job label):
 
         curl -X DELETE http://pushgateway.example.org:9091/metrics/job/some_job
+        
+* Delete all metrics in all groups (requires to enable the admin api`--web.enable-admin-api`)
+
+        curl -XPUT http://pushgateway.example.org:9091/api/v1/admin/wipe
 
 ### About the job and instance labels
 
@@ -320,6 +324,28 @@ guaranteed that the `DELETE` will be processed first (and vice versa).
 Deleting a grouping key without metrics is a no-op and will not result
 in an error.
 
+## Admin API
+
+The Admin API provides administrative access to the pushgateway, and must be
+explicitly enabled by setting `--web.enable-admin-api` flag.
+
+### URL
+
+The default port the push gateway is listening to is 9091. The path looks like
+
+    /api/<API_VERSION>/admin/<HANDLER>
+    
+ * Available endpoints:
+ 
+| HTTP_METHOD| API_VERSION |  HANDLER | DESCRIPTION |
+| :-------: |:-------------:| :-----:| :----- |
+| PUT     | v1 | wipe |  safely deletes all metrics within the push gateway |
+
+
+* For example to wipe all metrics within the pushgateway:
+
+        curl -XPUT http://pushgateway.example.org:9091/api/v1/admin/wipe
+        
 ## Exposed metrics
 
 The Pushgateway exposes the following metrics via the configured

--- a/README.md
+++ b/README.md
@@ -138,9 +138,9 @@ Examples:
 
         curl -X DELETE http://pushgateway.example.org:9091/metrics/job/some_job
         
-* Delete all metrics in all groups (requires to enable the admin api`--web.enable-admin-api`)
+* Delete all metrics in all groups (requires to enable the admin api`--web.enable-admin-api`):
 
-        curl -XPUT http://pushgateway.example.org:9091/api/v1/admin/wipe
+        curl -X PUT http://pushgateway.example.org:9091/api/v1/admin/wipe
 
 ### About the job and instance labels
 
@@ -326,12 +326,12 @@ in an error.
 
 ## Admin API
 
-The Admin API provides administrative access to the pushgateway, and must be
+The Admin API provides administrative access to the Pushgateway, and must be
 explicitly enabled by setting `--web.enable-admin-api` flag.
 
 ### URL
 
-The default port the push gateway is listening to is 9091. The path looks like
+The default port the Pushgateway is listening to is 9091. The path looks like:
 
     /api/<API_VERSION>/admin/<HANDLER>
     
@@ -339,12 +339,12 @@ The default port the push gateway is listening to is 9091. The path looks like
  
 | HTTP_METHOD| API_VERSION |  HANDLER | DESCRIPTION |
 | :-------: |:-------------:| :-----:| :----- |
-| PUT     | v1 | wipe |  safely deletes all metrics within the push gateway |
+| PUT     | v1 | wipe |  Safely deletes all metrics from the Pushgateway. |
 
 
-* For example to wipe all metrics within the pushgateway:
+* For example to wipe all metrics within the Pushgateway:
 
-        curl -XPUT http://pushgateway.example.org:9091/api/v1/admin/wipe
+        curl -X PUT http://pushgateway.example.org:9091/api/v1/admin/wipe
         
 ## Exposed metrics
 

--- a/README.md
+++ b/README.md
@@ -342,7 +342,7 @@ The default port the Pushgateway is listening to is 9091. The path looks like:
 | PUT     | v1 | wipe |  Safely deletes all metrics from the Pushgateway. |
 
 
-* For example to wipe all metrics within the Pushgateway:
+* For example to wipe all metrics from the Pushgateway:
 
         curl -X PUT http://pushgateway.example.org:9091/api/v1/admin/wipe
         


### PR DESCRIPTION
This is part of https://github.com/prometheus/pushgateway/issues/264

Is there anywhere else where this new endpoint should be documented?

https://github.com/prometheus/docs doesn't seem to contain such a detailed information about non-prometheus projects such as pushgateway.

Feel free to pass feedback and request changes, I just documented quickly right before going to sleep.

Cheers