### PR TITLE
Check pushed metrics immediately and reject them if inconsistent

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Examples:
 
         curl -X DELETE http://pushgateway.example.org:9091/metrics/job/some_job
         
-* Delete all metrics in all groups (requires to enable the admin api`--web.enable-admin-api`):
+* Delete all metrics in all groups (requires to enable the admin API via the command line flag `--web.enable-admin-api`):
 
         curl -X PUT http://pushgateway.example.org:9091/api/v1/admin/wipe
 
@@ -202,10 +202,12 @@ timestamps.
 If you think you need to push a timestamp, please see [When To Use The
 Pushgateway](https://prometheus.io/docs/practices/pushing/).
 
-In order to make it easier to alert on pushers that have not run recently, the
-Pushgateway will add in a metric `push_time_seconds` with the Unix timestamp
-of the last `POST`/`PUT` to each group. This will override any pushed metric by
-that name.
+In order to make it easier to alert on failed pushers or those that have not
+run recently, the Pushgateway will add in the metrics `push_time_seconds` and
+`push_failure_time_seconds` with the Unix timestamp of the last successful and
+failed `POST`/`PUT` to each group. This will override any pushed metric by that
+name. A value of zero for either metric implies that the group has never seen a
+successful or failed `POST`/`PUT`.
 
 ## API
 
@@ -277,20 +279,24 @@ header. (Use the value `application/vnd.google.protobuf;
 proto=io.prometheus.client.MetricFamily; encoding=delimited` for protocol
 buffers, otherwise the text format is tried as a fall-back.)
 
-The response code upon success is always 202 (even if the same
-grouping key has never been used before, i.e. there is no feedback to
-the client if the push has replaced an existing group of metrics or
-created a new one).
+The response code upon success is either 200 or 400. A 200 response implies a
+successful push, either replacing an existing group of metrics or creating a
+new one. A 400 response can happen if the request is malformed or if the pushed
+metrics are inconsistent with metrics pushed to other groups or collide with
+metrics of the Pushgateway itself. An explanation is returned in the body of
+the response and logged on error level.
+
+In rare cases, it is possible that the Pushgateway ends up with an inconsistent
+set of metrics already pushed. In that case, new pushes are also rejected as
+inconsistent even if the culprit is metrics that were pushed earlier. Delete
+the offending metrics to get out of that situation.
 
 _If using the protobuf format, do not send duplicate MetricFamily
 proto messages (i.e. more than one with the same name) in one push, as
 they will overwrite each other._
 
-A successfully finished request means that the pushed metrics are
-queued for an update of the storage. Scraping the push gateway may
-still yield the old results until the queued update is
-processed. Neither is there a guarantee that the pushed metrics are
-persisted to disk. (A server crash may cause data loss. Or the push
+Note that the Pushgateway doesn't provide any strong guarantees that the pushed
+metrics are persisted to disk. (A server crash may cause data loss. Or the push
 gateway is configured to not persist to disk at all.)
 
 A `PUT` request with an empty body effectively deletes all metrics with the
@@ -351,12 +357,14 @@ The default port the Pushgateway is listening to is 9091. The path looks like:
 The Pushgateway exposes the following metrics via the configured
 `--web.telemetry-path` (default: `/metrics`):
 - The pushed metrics.
-- For each pushed group, a metric `push_time_seconds` as explained above.
+- For each pushed group, a metric `push_time_seconds` and
+  `push_failure_time_seconds` as explained above.
 - The usual metrics provided by the [Prometheus Go client library](https://github.com/prometheus/client_golang), i.e.:
   - `process_...`
   - `go_...`
   - `promhttp_metric_handler_requests_...`
-- A number of metrics specific to the Pushgateway, as documented by the example scrape below.
+- A number of metrics specific to the Pushgateway, as documented by the example
+  scrape below.
 
 ```
 # HELP pushgateway_build_info A metric with a constant '1' value labeled by version, revision, branch, and goversion from which pushgateway was built.
@@ -385,7 +393,23 @@ pushgateway_http_requests_total{code="202",handler="push",method="post"} 6
 pushgateway_http_requests_total{code="400",handler="push",method="post"} 2
 
 ```
-  
+
+### Alerting on failed pushes
+
+It is in general a good idea to alert on `push_time_seconds` being much farther
+behind than expected. This will catch both failed pushes as well as pushers
+being down completely.
+
+To detect failed pushes much earlier, alert on `push_failure_time_seconds >
+push_time_seconds`.
+
+Pushes can also fail because they are malformed. In this case, they never reach
+any metric group and therefore won't set any `push_failure_time_seconds`
+metrics. Those pushes are still counted as
+`pushgateway_http_requests_total{code="400",handler="push"}`. You can alert on
+the `rate` of this metric, but you have to inspect the logs to identify the
+offending pusher.
+
 ## Development
 
 The normal binary embeds the web files in the `resources` directory.

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/shurcooL/httpfs v0.0.0-20190707220628-8d4bc4ba7749 // indirect
 	github.com/shurcooL/vfsgen v0.0.0-20181202132449-6a9ea43bcacd
 	golang.org/x/sys v0.0.0-20190909082730-f460065e899a // indirect
-	golang.org/x/tools v0.0.0-20190731214159-1e85ed8060aa // indirect
+	golang.org/x/tools v0.0.0-20190919031856-7460b8e10b7e // indirect
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
 )
 

--- a/go.sum
+++ b/go.sum
@@ -25,6 +25,7 @@ github.com/go-logfmt/logfmt v0.4.0 h1:MP4Eh7ZCb31lleYCFuwm0oe4/YGak+5l1vA2NOE80n
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/go-stack/stack v1.8.0 h1:5SgMzNM5HxrEjV0ww2lTmX6E2Izsfxas4+YHWRs3Lsk=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
+github.com/gogo/protobuf v1.1.1 h1:72R+M5VuhED/KujmZVcIquuo8mBgX4oVda//DQb3PXo=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/golang/protobuf v1.2.0 h1:P3YflyNX/ehuJFLhxviNdFxQPkGK5cDcApsge1SqnvM=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
@@ -95,10 +96,12 @@ golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2 h1:VklqNMn3ovrHsnt90Pveol
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/net v0.0.0-20181114220301-adae6a3d119a/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190613194153-d28f0bde5980/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20190620200207-3b0461eec859 h1:R/3boaszxrf1GEUWTVDzSKVwLmSJpwZ1yqXm8j0v2QI=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f h1:Bl/8QSvNqXvPGPGXa2z5xUTmV7VDcZyvRZ+QQXkXTZQ=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20190423024810-112230192c58 h1:8gQV6CLnAEikrhgkHFbMAEhagSSnXWGV915qUMm9mrU=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181116152217-5ac8a444bdc5/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -107,10 +110,14 @@ golang.org/x/sys v0.0.0-20190801041406-cbf593c0f2f3 h1:4y9KwBHBgBNwDbtu44R5o1fdO
 golang.org/x/sys v0.0.0-20190801041406-cbf593c0f2f3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190909082730-f460065e899a h1:mIzbOulag9/gXacgxKlFVwpCOWSfBT3/pDyyCwGA9as=
 golang.org/x/sys v0.0.0-20190909082730-f460065e899a/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
-golang.org/x/tools v0.0.0-20190731214159-1e85ed8060aa h1:kwa/4M1dbmhZqOIqYiTtbA6JrvPwo1+jqlub2qDXX90=
-golang.org/x/tools v0.0.0-20190731214159-1e85ed8060aa/go.mod h1:jcCCGcm9btYwXyDqrUWc6MKQKKGJCWEQ3AfLSRIbEuI=
+golang.org/x/tools v0.0.0-20190919031856-7460b8e10b7e h1:DxffoHYXmce3WTEBU/6/5bBSV7wmPSvT+atzBfv8hJI=
+golang.org/x/tools v0.0.0-20190919031856-7460b8e10b7e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7 h1:9zdDQZ7Thm29KFXgAX/+yaf3eVbP7djjWp/dXAppNCc=
+golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6 h1:jMFz6MfLP0/4fUyZle81rXUoxOBFi19VUFKVDOQfozc=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.1 h1:mUhvW9EsL+naU5Q3cakzfE91YhliOondGd6ZrsDBHQE=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/main.go
+++ b/main.go
@@ -95,8 +95,8 @@ func main() {
 
 	ms := storage.NewDiskMetricStore(*persistenceFile, *persistenceInterval, prometheus.DefaultGatherer, logger)
 
-	// Inject the metric families returned by ms.GetMetricFamilies into the default Gatherer:
-	prometheus.DefaultGatherer = prometheus.Gatherers{
+	// Create a Gatherer combining the DefaultGatherer and the metrics from the metric store.
+	g := prometheus.Gatherers{
 		prometheus.DefaultGatherer,
 		prometheus.GathererFunc(func() ([]*dto.MetricFamily, error) { return ms.GetMetricFamilies(), nil }),
 	}
@@ -106,7 +106,7 @@ func main() {
 	r.Handler("GET", *routePrefix+"/-/ready", handler.Ready(ms))
 	r.Handler(
 		"GET", path.Join(*routePrefix, *metricsPath),
-		promhttp.HandlerFor(prometheus.DefaultGatherer, promhttp.HandlerOpts{
+		promhttp.HandlerFor(g, promhttp.HandlerOpts{
 			ErrorLog: logFunc(level.Error(logger).Log),
 		}),
 	)

--- a/resources/template.html
+++ b/resources/template.html
@@ -68,7 +68,8 @@ limitations under the License.
 	    {{range $i, $ln := .SortedLabels}}
 	      <span class="badge {{if eq $ln "job"}}badge-warning{{else if eq $ln "instance"}}badge-primary{{else}}badge-info{{end}}">{{$ln}}="{{index $metricGroup.Labels $ln}}"</span>
 	    {{end}}
-	    </button>	     
+	    </button>
+	    {{if not $metricGroup.LastPushSuccess}}<span class="badge badge-pill badge-danger" role="alert">Last push failed!</span>{{end}}
 	    <button class="btn btn-xs btn-danger float-right" onclick="pushgateway.showDelModal({ {{range $i, $ln := .SortedLabels}}{{if $i}}, {{end}}'{{$ln}}': '{{index $metricGroup.Labels $ln}}'{{end}} }, { {{range $i, $ln := .SortedLabels}}{{if $i}}, {{end}}'{{$ln}}': '{{index $metricGroup.Labels $ln | base64}}'{{end}} }, 'group-panel-{{$gCount}}', event)">Delete Group</button>
 	  </h2>
 	</div>

--- a/storage/diskmetricstore_test.go
+++ b/storage/diskmetricstore_test.go
@@ -33,7 +33,7 @@ import (
 
 var (
 	logger = log.NewNopLogger()
-	// Example metric families.
+	// Example metric families. Keep labels sorted lexicographically!
 	mf1a = &dto.MetricFamily{
 		Name: proto.String("mf1"),
 		Type: dto.MetricType_UNTYPED.Enum(),
@@ -41,18 +41,17 @@ var (
 			{
 				Label: []*dto.LabelPair{
 					{
-						Name:  proto.String("job"),
-						Value: proto.String("job1"),
-					},
-					{
 						Name:  proto.String("instance"),
 						Value: proto.String("instance2"),
+					},
+					{
+						Name:  proto.String("job"),
+						Value: proto.String("job1"),
 					},
 				},
 				Untyped: &dto.Untyped{
 					Value: proto.Float64(-3e3),
 				},
-				TimestampMs: proto.Int64(103948),
 			},
 		},
 	}
@@ -63,12 +62,12 @@ var (
 			{
 				Label: []*dto.LabelPair{
 					{
-						Name:  proto.String("job"),
-						Value: proto.String("job1"),
-					},
-					{
 						Name:  proto.String("instance"),
 						Value: proto.String("instance2"),
+					},
+					{
+						Name:  proto.String("job"),
+						Value: proto.String("job1"),
 					},
 				},
 				Untyped: &dto.Untyped{
@@ -84,12 +83,12 @@ var (
 			{
 				Label: []*dto.LabelPair{
 					{
-						Name:  proto.String("job"),
-						Value: proto.String("job2"),
-					},
-					{
 						Name:  proto.String("instance"),
 						Value: proto.String("instance1"),
+					},
+					{
+						Name:  proto.String("job"),
+						Value: proto.String("job2"),
 					},
 				},
 				Untyped: &dto.Untyped{
@@ -105,12 +104,29 @@ var (
 			{
 				Label: []*dto.LabelPair{
 					{
+						Name:  proto.String("instance"),
+						Value: proto.String("instance2"),
+					},
+					{
 						Name:  proto.String("job"),
 						Value: proto.String("job3"),
 					},
+				},
+				Untyped: &dto.Untyped{
+					Value: proto.Float64(42),
+				},
+			},
+		},
+	}
+	mf1e = &dto.MetricFamily{
+		Name: proto.String("mf1"),
+		Type: dto.MetricType_UNTYPED.Enum(),
+		Metric: []*dto.Metric{
+			{
+				Label: []*dto.LabelPair{
 					{
-						Name:  proto.String("instance"),
-						Value: proto.String("instance2"),
+						Name:  proto.String("job"),
+						Value: proto.String("job1"),
 					},
 				},
 				Untyped: &dto.Untyped{
@@ -127,48 +143,107 @@ var (
 			{
 				Label: []*dto.LabelPair{
 					{
+						Name:  proto.String("instance"),
+						Value: proto.String("instance2"),
+					},
+					{
 						Name:  proto.String("job"),
 						Value: proto.String("job1"),
 					},
+				},
+				Untyped: &dto.Untyped{
+					Value: proto.Float64(-3e3),
+				},
+			},
+			{
+				Label: []*dto.LabelPair{
+					{
+						Name:  proto.String("instance"),
+						Value: proto.String("instance1"),
+					},
+					{
+						Name:  proto.String("job"),
+						Value: proto.String("job2"),
+					},
+				},
+				Untyped: &dto.Untyped{
+					Value: proto.Float64(42),
+				},
+			},
+			{
+				Label: []*dto.LabelPair{
 					{
 						Name:  proto.String("instance"),
 						Value: proto.String("instance2"),
+					},
+					{
+						Name:  proto.String("job"),
+						Value: proto.String("job3"),
+					},
+				},
+				Untyped: &dto.Untyped{
+					Value: proto.Float64(42),
+				},
+			},
+		},
+	}
+	// mf1be is merged from mf1b and mf1e, with added empty instance label for mf1e.
+	mf1be = &dto.MetricFamily{
+		Name: proto.String("mf1"),
+		Type: dto.MetricType_UNTYPED.Enum(),
+		Metric: []*dto.Metric{
+			{
+				Label: []*dto.LabelPair{
+					{
+						Name:  proto.String("instance"),
+						Value: proto.String("instance2"),
+					},
+					{
+						Name:  proto.String("job"),
+						Value: proto.String("job1"),
+					},
+				},
+				Untyped: &dto.Untyped{
+					Value: proto.Float64(42),
+				},
+			},
+			{
+				Label: []*dto.LabelPair{
+					{
+						Name:  proto.String("instance"),
+						Value: proto.String(""),
+					},
+					{
+						Name:  proto.String("job"),
+						Value: proto.String("job1"),
+					},
+				},
+				Untyped: &dto.Untyped{
+					Value: proto.Float64(42),
+				},
+			},
+		},
+	}
+	// mf1ts is mf1a with a timestamp set.
+	mf1ts = &dto.MetricFamily{
+		Name: proto.String("mf1"),
+		Type: dto.MetricType_UNTYPED.Enum(),
+		Metric: []*dto.Metric{
+			{
+				Label: []*dto.LabelPair{
+					{
+						Name:  proto.String("instance"),
+						Value: proto.String("instance2"),
+					},
+					{
+						Name:  proto.String("job"),
+						Value: proto.String("job1"),
 					},
 				},
 				Untyped: &dto.Untyped{
 					Value: proto.Float64(-3e3),
 				},
 				TimestampMs: proto.Int64(103948),
-			},
-			{
-				Label: []*dto.LabelPair{
-					{
-						Name:  proto.String("job"),
-						Value: proto.String("job2"),
-					},
-					{
-						Name:  proto.String("instance"),
-						Value: proto.String("instance1"),
-					},
-				},
-				Untyped: &dto.Untyped{
-					Value: proto.Float64(42),
-				},
-			},
-			{
-				Label: []*dto.LabelPair{
-					{
-						Name:  proto.String("job"),
-						Value: proto.String("job3"),
-					},
-					{
-						Name:  proto.String("instance"),
-						Value: proto.String("instance2"),
-					},
-				},
-				Untyped: &dto.Untyped{
-					Value: proto.Float64(42),
-				},
 			},
 		},
 	}
@@ -180,36 +255,35 @@ var (
 			{
 				Label: []*dto.LabelPair{
 					{
-						Name:  proto.String("job"),
-						Value: proto.String("job1"),
+						Name:  proto.String("basename"),
+						Value: proto.String("basevalue2"),
 					},
 					{
 						Name:  proto.String("instance"),
 						Value: proto.String("instance2"),
+					},
+					{
+						Name:  proto.String("job"),
+						Value: proto.String("job1"),
 					},
 					{
 						Name:  proto.String("labelname"),
 						Value: proto.String("val2"),
 					},
-					{
-						Name:  proto.String("basename"),
-						Value: proto.String("basevalue2"),
-					},
 				},
 				Gauge: &dto.Gauge{
 					Value: proto.Float64(math.Inf(+1)),
 				},
-				TimestampMs: proto.Int64(54321),
 			},
 			{
 				Label: []*dto.LabelPair{
 					{
-						Name:  proto.String("job"),
-						Value: proto.String("job1"),
-					},
-					{
 						Name:  proto.String("instance"),
 						Value: proto.String("instance2"),
+					},
+					{
+						Name:  proto.String("job"),
+						Value: proto.String("job1"),
 					},
 					{
 						Name:  proto.String("labelname"),
@@ -229,12 +303,12 @@ var (
 			{
 				Label: []*dto.LabelPair{
 					{
-						Name:  proto.String("job"),
-						Value: proto.String("job1"),
-					},
-					{
 						Name:  proto.String("instance"),
 						Value: proto.String("instance1"),
+					},
+					{
+						Name:  proto.String("job"),
+						Value: proto.String("job1"),
 					},
 				},
 				Untyped: &dto.Untyped{
@@ -250,12 +324,12 @@ var (
 			{
 				Label: []*dto.LabelPair{
 					{
-						Name:  proto.String("job"),
-						Value: proto.String("job3"),
-					},
-					{
 						Name:  proto.String("instance"),
 						Value: proto.String("instance2"),
+					},
+					{
+						Name:  proto.String("job"),
+						Value: proto.String("job3"),
 					},
 				},
 				Untyped: &dto.Untyped{
@@ -271,12 +345,12 @@ var (
 			{
 				Label: []*dto.LabelPair{
 					{
-						Name:  proto.String("job"),
-						Value: proto.String("job5"),
-					},
-					{
 						Name:  proto.String("instance"),
 						Value: proto.String("instance5"),
+					},
+					{
+						Name:  proto.String("job"),
+						Value: proto.String("job5"),
 					},
 				},
 				Summary: &dto.Summary{
@@ -293,6 +367,10 @@ var (
 		Metric: []*dto.Metric{
 			{
 				Label: []*dto.LabelPair{
+					{
+						Name:  proto.String("instance"),
+						Value: proto.String(""),
+					},
 					{
 						Name:  proto.String("job"),
 						Value: proto.String("job1"),
@@ -311,6 +389,10 @@ var (
 		Metric: []*dto.Metric{
 			{
 				Label: []*dto.LabelPair{
+					{
+						Name:  proto.String("instance"),
+						Value: proto.String(""),
+					},
 					{
 						Name:  proto.String("job"),
 						Value: proto.String("job2"),
@@ -331,6 +413,10 @@ var (
 			{
 				Label: []*dto.LabelPair{
 					{
+						Name:  proto.String("instance"),
+						Value: proto.String(""),
+					},
+					{
 						Name:  proto.String("job"),
 						Value: proto.String("job1"),
 					},
@@ -341,6 +427,10 @@ var (
 			},
 			{
 				Label: []*dto.LabelPair{
+					{
+						Name:  proto.String("instance"),
+						Value: proto.String(""),
+					},
 					{
 						Name:  proto.String("job"),
 						Value: proto.String("job2"),
@@ -361,6 +451,10 @@ var (
 			{
 				Label: []*dto.LabelPair{
 					{
+						Name:  proto.String("instance"),
+						Value: proto.String(""),
+					},
+					{
 						Name:  proto.String("job"),
 						Value: proto.String("job1"),
 					},
@@ -372,6 +466,10 @@ var (
 			{
 				Label: []*dto.LabelPair{
 					{
+						Name:  proto.String("instance"),
+						Value: proto.String(""),
+					},
+					{
 						Name:  proto.String("job"),
 						Value: proto.String("job2"),
 					},
@@ -382,6 +480,7 @@ var (
 			},
 		},
 	}
+	// mfgg is the usual go_goroutines gauge but with a different help text.
 	mfgg = &dto.MetricFamily{
 		Name: proto.String("go_goroutines"),
 		Help: proto.String("Inconsistent doc string, fixed version in mfggFixed."),
@@ -390,11 +489,38 @@ var (
 			{
 				Label: []*dto.LabelPair{
 					{
+						Name:  proto.String("instance"),
+						Value: proto.String(""),
+					},
+					{
 						Name:  proto.String("job"),
 						Value: proto.String("job1"),
 					},
 				},
 				Gauge: &dto.Gauge{
+					Value: proto.Float64(5),
+				},
+			},
+		},
+	}
+	// mfgc is the usual go_goroutines metric but mistyped as counter.
+	mfgc = &dto.MetricFamily{
+		Name: proto.String("go_goroutines"),
+		Help: proto.String("Number of goroutines that currently exist."),
+		Type: dto.MetricType_COUNTER.Enum(),
+		Metric: []*dto.Metric{
+			{
+				Label: []*dto.LabelPair{
+					{
+						Name:  proto.String("instance"),
+						Value: proto.String(""),
+					},
+					{
+						Name:  proto.String("job"),
+						Value: proto.String("job1"),
+					},
+				},
+				Counter: &dto.Counter{
 					Value: proto.Float64(5),
 				},
 			},
@@ -408,6 +534,10 @@ var (
 			{
 				Label: []*dto.LabelPair{
 					{
+						Name:  proto.String("instance"),
+						Value: proto.String(""),
+					},
+					{
 						Name:  proto.String("job"),
 						Value: proto.String("job1"),
 					},
@@ -419,6 +549,27 @@ var (
 		},
 	}
 )
+
+// metricFamiliesMap creates the map needed in the MetricFamilies field of a
+// WriteRequest from the provided reference metric families. While doing so, it
+// creates deep copies of the metric families so that modifications that might
+// happen during processing of the WriteRequest will not affect the reference
+// metric families.
+func metricFamiliesMap(mfs ...*dto.MetricFamily) map[string]*dto.MetricFamily {
+	m := map[string]*dto.MetricFamily{}
+	for _, mf := range mfs {
+		buf, err := proto.Marshal(mf)
+		if err != nil {
+			panic(err)
+		}
+		mfCopy := &dto.MetricFamily{}
+		if err := proto.Unmarshal(buf, mfCopy); err != nil {
+			panic(err)
+		}
+		m[mf.GetName()] = mfCopy
+	}
+	return m
+}
 
 func addGroup(
 	mg GroupingKeyToMetricGroup,
@@ -529,61 +680,106 @@ func TestAddDeletePersistRestore(t *testing.T) {
 
 	// Submit a single simple metric family.
 	ts1 := time.Now()
+	grouping1 := map[string]string{
+		"job":      "job1",
+		"instance": "instance1",
+	}
+	errCh := make(chan error, 1)
 	dms.SubmitWriteRequest(WriteRequest{
-		Labels: map[string]string{
-			"job":      "job1",
-			"instance": "instance1",
-		},
+		Labels:         grouping1,
 		Timestamp:      ts1,
-		MetricFamilies: map[string]*dto.MetricFamily{"mf3": mf3},
+		MetricFamilies: metricFamiliesMap(mf3),
+		Done:           errCh,
 	})
-	time.Sleep(20 * time.Millisecond) // Give loop() time to process.
-	if err := checkMetricFamilies(dms, mf3); err != nil {
+	for err := range errCh {
+		t.Fatal("Unexpected error:", err)
+	}
+	pushTimestamp := newPushTimestampGauge(grouping1, ts1)
+	pushFailedTimestamp := newPushFailedTimestampGauge(grouping1, time.Time{})
+	if err := checkMetricFamilies(
+		dms, mf3,
+		pushTimestamp, pushFailedTimestamp,
+	); err != nil {
 		t.Error(err)
 	}
 
 	// Submit two metric families for a different instance.
 	ts2 := ts1.Add(time.Second)
+	grouping2 := map[string]string{
+		"job":      "job1",
+		"instance": "instance2",
+	}
+	errCh = make(chan error, 1)
 	dms.SubmitWriteRequest(WriteRequest{
-		Labels: map[string]string{
-			"job":      "job1",
-			"instance": "instance2",
-		},
+		Labels:         grouping2,
 		Timestamp:      ts2,
-		MetricFamilies: map[string]*dto.MetricFamily{"mf1": mf1b, "mf2": mf2},
+		MetricFamilies: metricFamiliesMap(mf1b, mf2),
+		Done:           errCh,
 	})
-	time.Sleep(20 * time.Millisecond) // Give loop() time to process.
-	if err := checkMetricFamilies(dms, mf1b, mf2, mf3); err != nil {
+	for err := range errCh {
+		t.Fatal("Unexpected error:", err)
+	}
+	pushTimestamp.Metric = append(
+		pushTimestamp.Metric, newPushTimestampGauge(grouping2, ts2).Metric[0],
+	)
+	pushFailedTimestamp.Metric = append(
+		pushFailedTimestamp.Metric, newPushFailedTimestampGauge(grouping2, time.Time{}).Metric[0],
+	)
+	if err := checkMetricFamilies(
+		dms, mf1b, mf2, mf3,
+		pushTimestamp, pushFailedTimestamp,
+	); err != nil {
 		t.Error(err)
 	}
-
+	for err := range errCh {
+		t.Fatal("Unexpected error:", err)
+	}
 	// Submit a metric family with the same name for the same job/instance again.
 	// Should overwrite the previous metric family for the same job/instance
 	ts3 := ts2.Add(time.Second)
+	errCh = make(chan error, 1)
 	dms.SubmitWriteRequest(WriteRequest{
-		Labels: map[string]string{
-			"job":      "job1",
-			"instance": "instance2",
-		},
+		Labels:         grouping2,
 		Timestamp:      ts3,
-		MetricFamilies: map[string]*dto.MetricFamily{"mf1": mf1a},
+		MetricFamilies: metricFamiliesMap(mf1a),
+		Done:           errCh,
 	})
-	time.Sleep(20 * time.Millisecond) // Give loop() time to process.
-	if err := checkMetricFamilies(dms, mf1a, mf2, mf3); err != nil {
+	for err := range errCh {
+		t.Fatal("Unexpected error:", err)
+	}
+	pushTimestamp.Metric[1] = newPushTimestampGauge(grouping2, ts3).Metric[0]
+	if err := checkMetricFamilies(
+		dms, mf1a, mf2, mf3,
+		pushTimestamp, pushFailedTimestamp,
+	); err != nil {
 		t.Error(err)
 	}
 
 	// Add a new group by job, with a summary without any observations yet.
 	ts4 := ts3.Add(time.Second)
+	grouping4 := map[string]string{
+		"job": "job5",
+	}
+	errCh = make(chan error, 1)
 	dms.SubmitWriteRequest(WriteRequest{
-		Labels: map[string]string{
-			"job": "job5",
-		},
+		Labels:         grouping4,
 		Timestamp:      ts4,
-		MetricFamilies: map[string]*dto.MetricFamily{"mf5": mf5},
+		MetricFamilies: metricFamiliesMap(mf5),
+		Done:           errCh,
 	})
-	time.Sleep(20 * time.Millisecond) // Give loop() time to process.
-	if err := checkMetricFamilies(dms, mf1a, mf2, mf3, mf5); err != nil {
+	for err := range errCh {
+		t.Fatal("Unexpected error:", err)
+	}
+	pushTimestamp.Metric = append(
+		pushTimestamp.Metric, newPushTimestampGauge(grouping4, ts4).Metric[0],
+	)
+	pushFailedTimestamp.Metric = append(
+		pushFailedTimestamp.Metric, newPushFailedTimestampGauge(grouping4, time.Time{}).Metric[0],
+	)
+	if err := checkMetricFamilies(
+		dms, mf1a, mf2, mf3, mf5,
+		pushTimestamp, pushFailedTimestamp,
+	); err != nil {
 		t.Error(err)
 	}
 
@@ -594,7 +790,10 @@ func TestAddDeletePersistRestore(t *testing.T) {
 
 	// Load it again.
 	dms = NewDiskMetricStore(fileName, 100*time.Millisecond, nil, logger)
-	if err := checkMetricFamilies(dms, mf1a, mf2, mf3, mf5); err != nil {
+	if err := checkMetricFamilies(
+		dms, mf1a, mf2, mf3, mf5,
+		pushTimestamp, pushFailedTimestamp,
+	); err != nil {
 		t.Error(err)
 	}
 	// Spot-check timestamp.
@@ -613,59 +812,92 @@ func TestAddDeletePersistRestore(t *testing.T) {
 			"instance": "instance1",
 		},
 	})
+	errCh = make(chan error, 1)
 	dms.SubmitWriteRequest(WriteRequest{
 		Labels: map[string]string{
 			"job": "job5",
 		},
+		Done: errCh,
 	})
-	time.Sleep(20 * time.Millisecond) // Give loop() time to process.
-	if err := checkMetricFamilies(dms, mf1a, mf2); err != nil {
+	for err := range errCh {
+		t.Fatal("Unexpected error:", err)
+	}
+	pushTimestamp = newPushTimestampGauge(grouping2, ts3)
+	pushFailedTimestamp = newPushFailedTimestampGauge(grouping2, time.Time{})
+	if err := checkMetricFamilies(
+		dms, mf1a, mf2,
+		pushTimestamp, pushFailedTimestamp,
+	); err != nil {
 		t.Error(err)
 	}
 
 	// Submit another one.
 	ts5 := ts4.Add(time.Second)
+	grouping5 := map[string]string{
+		"job":      "job3",
+		"instance": "instance2",
+	}
+	errCh = make(chan error, 1)
 	dms.SubmitWriteRequest(WriteRequest{
-		Labels: map[string]string{
-			"job":      "job3",
-			"instance": "instance2",
-		},
+		Labels:         grouping5,
 		Timestamp:      ts5,
-		MetricFamilies: map[string]*dto.MetricFamily{"mf4": mf4},
+		MetricFamilies: metricFamiliesMap(mf4),
+		Done:           errCh,
 	})
-	time.Sleep(20 * time.Millisecond) // Give loop() time to process.
-	if err := checkMetricFamilies(dms, mf1a, mf2, mf4); err != nil {
+	for err := range errCh {
+		t.Fatal("Unexpected error:", err)
+	}
+	pushTimestamp.Metric = append(
+		pushTimestamp.Metric, newPushTimestampGauge(grouping5, ts5).Metric[0],
+	)
+	pushFailedTimestamp.Metric = append(
+		pushFailedTimestamp.Metric, newPushFailedTimestampGauge(grouping5, time.Time{}).Metric[0],
+	)
+	if err := checkMetricFamilies(
+		dms, mf1a, mf2, mf4,
+		pushTimestamp, pushFailedTimestamp,
+	); err != nil {
 		t.Error(err)
 	}
 
 	// Delete a job does not remove anything because there is no suitable
 	// grouping.
+	errCh = make(chan error, 1)
 	dms.SubmitWriteRequest(WriteRequest{
 		Labels: map[string]string{
 			"job": "job1",
 		},
+		Done: errCh,
 	})
-	time.Sleep(20 * time.Millisecond) // Give loop() time to process.
-	if err := checkMetricFamilies(dms, mf1a, mf2, mf4); err != nil {
+	for err := range errCh {
+		t.Fatal("Unexpected error:", err)
+	}
+	if err := checkMetricFamilies(
+		dms, mf1a, mf2, mf4,
+		pushTimestamp, pushFailedTimestamp,
+	); err != nil {
 		t.Error(err)
 	}
 
 	// Delete another group.
+	errCh = make(chan error, 1)
 	dms.SubmitWriteRequest(WriteRequest{
-		Labels: map[string]string{
-			"job":      "job3",
-			"instance": "instance2",
-		},
+		Labels: grouping5,
+		Done:   errCh,
 	})
-	time.Sleep(20 * time.Millisecond) // Give loop() time to process.
-	if err := checkMetricFamilies(dms, mf1a, mf2); err != nil {
+	for err := range errCh {
+		t.Fatal("Unexpected error:", err)
+	}
+	pushTimestamp = newPushTimestampGauge(grouping2, ts3)
+	pushFailedTimestamp = newPushFailedTimestampGauge(grouping2, time.Time{})
+	if err := checkMetricFamilies(
+		dms, mf1a, mf2,
+		pushTimestamp, pushFailedTimestamp,
+	); err != nil {
 		t.Error(err)
 	}
 	// Check that no empty map entry for job3 was left behind.
-	if _, stillExists := dms.metricGroups[model.LabelsToSignature(map[string]string{
-		"job":      "job3",
-		"instance": "instance2",
-	})]; stillExists {
+	if _, stillExists := dms.metricGroups[model.LabelsToSignature(grouping5)]; stillExists {
 		t.Error("An instance map for 'job3' still exists.")
 	}
 
@@ -673,18 +905,24 @@ func TestAddDeletePersistRestore(t *testing.T) {
 	// (to check draining).
 	for i := 0; i < 10; i++ {
 		dms.SubmitWriteRequest(WriteRequest{
-			Labels: map[string]string{
-				"job":      "job3",
-				"instance": "instance2",
-			},
-			Timestamp:      ts4,
-			MetricFamilies: map[string]*dto.MetricFamily{"mf4": mf4},
+			Labels:         grouping5,
+			Timestamp:      ts5,
+			MetricFamilies: metricFamiliesMap(mf4),
 		})
 	}
 	if err := dms.Shutdown(); err != nil {
 		t.Fatal(err)
 	}
-	if err := checkMetricFamilies(dms, mf1a, mf2, mf4); err != nil {
+	pushTimestamp.Metric = append(
+		pushTimestamp.Metric, newPushTimestampGauge(grouping5, ts5).Metric[0],
+	)
+	pushFailedTimestamp.Metric = append(
+		pushFailedTimestamp.Metric, newPushFailedTimestampGauge(grouping5, time.Time{}).Metric[0],
+	)
+	if err := checkMetricFamilies(
+		dms, mf1a, mf2, mf4,
+		pushTimestamp, pushFailedTimestamp,
+	); err != nil {
 		t.Error(err)
 	}
 }
@@ -693,16 +931,26 @@ func TestNoPersistence(t *testing.T) {
 	dms := NewDiskMetricStore("", 100*time.Millisecond, nil, logger)
 
 	ts1 := time.Now()
+	grouping1 := map[string]string{
+		"job":      "job1",
+		"instance": "instance1",
+	}
+	errCh := make(chan error, 1)
 	dms.SubmitWriteRequest(WriteRequest{
-		Labels: map[string]string{
-			"job":      "job1",
-			"instance": "instance1",
-		},
+		Labels:         grouping1,
 		Timestamp:      ts1,
-		MetricFamilies: map[string]*dto.MetricFamily{"mf3": mf3},
+		MetricFamilies: metricFamiliesMap(mf3),
+		Done:           errCh,
 	})
-	time.Sleep(20 * time.Millisecond) // Give loop() time to process.
-	if err := checkMetricFamilies(dms, mf3); err != nil {
+	for err := range errCh {
+		t.Fatal("Unexpected error:", err)
+	}
+	pushTimestamp := newPushTimestampGauge(grouping1, ts1)
+	pushFailedTimestamp := newPushFailedTimestampGauge(grouping1, time.Time{})
+	if err := checkMetricFamilies(
+		dms, mf3,
+		pushTimestamp, pushFailedTimestamp,
+	); err != nil {
 		t.Error(err)
 	}
 
@@ -724,6 +972,340 @@ func TestNoPersistence(t *testing.T) {
 	}
 }
 
+func TestRejectTimestamps(t *testing.T) {
+	dms := NewDiskMetricStore("", 100*time.Millisecond, nil, logger)
+
+	ts1 := time.Now()
+	grouping1 := map[string]string{
+		"job":      "job1",
+		"instance": "instance1",
+	}
+	errCh := make(chan error, 1)
+	dms.SubmitWriteRequest(WriteRequest{
+		Labels:         grouping1,
+		Timestamp:      ts1,
+		MetricFamilies: metricFamiliesMap(mf1ts),
+		Done:           errCh,
+	})
+	var err error
+	for err = range errCh {
+		if err != errTimestamp {
+			t.Errorf("Expected error %q, got %q.", errTimestamp, err)
+		}
+	}
+	if err == nil {
+		t.Error("Expected error on pushing metric with timestamp.")
+	}
+	pushTimestamp := newPushTimestampGauge(grouping1, time.Time{})
+	pushFailedTimestamp := newPushFailedTimestampGauge(grouping1, ts1)
+	if err := checkMetricFamilies(
+		dms,
+		pushTimestamp, pushFailedTimestamp,
+	); err != nil {
+		t.Error(err)
+	}
+
+	if err := dms.Shutdown(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRejectInconsistentPush(t *testing.T) {
+	dms := NewDiskMetricStore("", 100*time.Millisecond, nil, logger)
+
+	ts1 := time.Now()
+	grouping1 := map[string]string{
+		"job": "job1",
+	}
+	errCh := make(chan error, 1)
+	dms.SubmitWriteRequest(WriteRequest{
+		Labels:         grouping1,
+		Timestamp:      ts1,
+		MetricFamilies: metricFamiliesMap(mfgc),
+		Done:           errCh,
+	})
+	var err error
+	for err = range errCh {
+	}
+	if err == nil {
+		t.Error("Expected error pushing inconsistent go_goroutines metric.")
+	}
+	pushTimestamp := newPushTimestampGauge(grouping1, time.Time{})
+	pushFailedTimestamp := newPushFailedTimestampGauge(grouping1, ts1)
+	if err := checkMetricFamilies(
+		dms,
+		pushTimestamp, pushFailedTimestamp,
+	); err != nil {
+		t.Error(err)
+	}
+
+	ts2 := ts1.Add(time.Second)
+	errCh = make(chan error, 1)
+	dms.SubmitWriteRequest(WriteRequest{
+		Labels:         grouping1,
+		Timestamp:      ts2,
+		MetricFamilies: metricFamiliesMap(mf1a),
+		Done:           errCh,
+	})
+	for err := range errCh {
+		t.Fatal("Unexpected error:", err)
+	}
+	pushTimestamp = newPushTimestampGauge(grouping1, ts2)
+	if err := checkMetricFamilies(
+		dms, mf1a,
+		pushTimestamp, pushFailedTimestamp,
+	); err != nil {
+		t.Error(err)
+	}
+
+	ts3 := ts2.Add(time.Second)
+	grouping3 := map[string]string{
+		"job":      "job1",
+		"instance": "instance2",
+	}
+	errCh = make(chan error, 1)
+	dms.SubmitWriteRequest(WriteRequest{
+		Labels:         grouping3,
+		Timestamp:      ts3,
+		MetricFamilies: metricFamiliesMap(mf1b),
+		Done:           errCh,
+	})
+	err = nil
+	for err = range errCh {
+	}
+	if err == nil {
+		t.Error("Expected error pushing duplicate mf1 metric.")
+	}
+	pushTimestamp.Metric = append(
+		pushTimestamp.Metric, newPushTimestampGauge(grouping3, time.Time{}).Metric[0],
+	)
+	pushFailedTimestamp.Metric = append(
+		pushFailedTimestamp.Metric, newPushFailedTimestampGauge(grouping3, ts3).Metric[0],
+	)
+	if err := checkMetricFamilies(
+		dms, mf1a,
+		pushTimestamp, pushFailedTimestamp,
+	); err != nil {
+		t.Error(err)
+	}
+
+	if err := dms.Shutdown(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestSanitizeLabels(t *testing.T) {
+	dms := NewDiskMetricStore("", 100*time.Millisecond, nil, logger)
+
+	// Push mf1c with the grouping matching mf1b, mf1b should end up in storage.
+	ts1 := time.Now()
+	grouping1 := map[string]string{
+		"job":      "job1",
+		"instance": "instance2",
+	}
+	errCh := make(chan error, 1)
+	dms.SubmitWriteRequest(WriteRequest{
+		Labels:         grouping1,
+		Timestamp:      ts1,
+		MetricFamilies: metricFamiliesMap(mf1c),
+		Done:           errCh,
+	})
+	for err := range errCh {
+		t.Fatal("Unexpected error:", err)
+	}
+	pushTimestamp := newPushTimestampGauge(grouping1, ts1)
+	pushFailedTimestamp := newPushFailedTimestampGauge(grouping1, time.Time{})
+	if err := checkMetricFamilies(
+		dms, mf1b,
+		pushTimestamp, pushFailedTimestamp,
+	); err != nil {
+		t.Error(err)
+	}
+
+	// Push mf1e, missing the instance label. Again, mf1b should end up in storage.
+	ts2 := ts1.Add(1)
+	errCh = make(chan error, 1)
+	dms.SubmitWriteRequest(WriteRequest{
+		Labels:         grouping1,
+		Timestamp:      ts2,
+		MetricFamilies: metricFamiliesMap(mf1e),
+		Done:           errCh,
+	})
+	for err := range errCh {
+		t.Fatal("Unexpected error:", err)
+	}
+	pushTimestamp = newPushTimestampGauge(grouping1, ts2)
+	if err := checkMetricFamilies(
+		dms, mf1b,
+		pushTimestamp, pushFailedTimestamp,
+	); err != nil {
+		t.Error(err)
+	}
+
+	// Push mf1e, missing the instance label, into a grouping without the
+	// instance label. The result in the storage should have an empty
+	// instance label.
+	ts3 := ts2.Add(1)
+	grouping3 := map[string]string{
+		"job": "job1",
+	}
+	errCh = make(chan error, 1)
+	dms.SubmitWriteRequest(WriteRequest{
+		Labels:         grouping3,
+		Timestamp:      ts3,
+		MetricFamilies: metricFamiliesMap(mf1e),
+		Done:           errCh,
+	})
+	for err := range errCh {
+		t.Fatal("Unexpected error:", err)
+	}
+	pushTimestamp.Metric = append(
+		pushTimestamp.Metric, newPushTimestampGauge(grouping3, ts3).Metric[0],
+	)
+	pushFailedTimestamp.Metric = append(
+		pushFailedTimestamp.Metric, newPushFailedTimestampGauge(grouping3, time.Time{}).Metric[0],
+	)
+	if err := checkMetricFamilies(
+		dms, mf1be,
+		pushTimestamp, pushFailedTimestamp,
+	); err != nil {
+		t.Error(err)
+	}
+
+}
+
+func TestReplace(t *testing.T) {
+	dms := NewDiskMetricStore("", 100*time.Millisecond, nil, logger)
+
+	// First do an invalid push to set pushFailedTimestamp and to later
+	// verify that it is retained and not replaced.
+	ts1 := time.Now()
+	grouping1 := map[string]string{
+		"job": "job1",
+	}
+	errCh := make(chan error, 1)
+	dms.SubmitWriteRequest(WriteRequest{
+		Labels:         grouping1,
+		Timestamp:      ts1,
+		MetricFamilies: metricFamiliesMap(mf1ts),
+		Done:           errCh,
+	})
+	var err error
+	for err = range errCh {
+		if err != errTimestamp {
+			t.Errorf("Expected error %q, got %q.", errTimestamp, err)
+		}
+	}
+	if err == nil {
+		t.Error("Expected error on pushing metric with timestamp.")
+	}
+	pushTimestamp := newPushTimestampGauge(grouping1, time.Time{})
+	pushFailedTimestamp := newPushFailedTimestampGauge(grouping1, ts1)
+	if err := checkMetricFamilies(
+		dms,
+		pushTimestamp, pushFailedTimestamp,
+	); err != nil {
+		t.Error(err)
+	}
+
+	// Now a valid update in replace mode. It doesn't replace anything, but
+	// it already tests that the push-failed timestamp is retained.
+	ts2 := ts1.Add(time.Second)
+	errCh = make(chan error, 1)
+	dms.SubmitWriteRequest(WriteRequest{
+		Labels:         grouping1,
+		Timestamp:      ts2,
+		MetricFamilies: metricFamiliesMap(mf1a),
+		Done:           errCh,
+		Replace:        true,
+	})
+	for err := range errCh {
+		t.Fatal("Unexpected error:", err)
+	}
+	pushTimestamp = newPushTimestampGauge(grouping1, ts2)
+	if err := checkMetricFamilies(
+		dms, mf1a,
+		pushTimestamp, pushFailedTimestamp,
+	); err != nil {
+		t.Error(err)
+	}
+
+	// Now push something else in replace mode that should replace mf1.
+	ts3 := ts2.Add(time.Second)
+	errCh = make(chan error, 1)
+	dms.SubmitWriteRequest(WriteRequest{
+		Labels:         grouping1,
+		Timestamp:      ts3,
+		MetricFamilies: metricFamiliesMap(mf2),
+		Done:           errCh,
+		Replace:        true,
+	})
+	for err := range errCh {
+		t.Fatal("Unexpected error:", err)
+	}
+	pushTimestamp = newPushTimestampGauge(grouping1, ts3)
+	if err := checkMetricFamilies(
+		dms, mf2,
+		pushTimestamp, pushFailedTimestamp,
+	); err != nil {
+		t.Error(err)
+	}
+
+	// Another invalid push in replace mode, which should only update the
+	// push-failed timestamp.
+	ts4 := ts3.Add(time.Second)
+	errCh = make(chan error, 1)
+	dms.SubmitWriteRequest(WriteRequest{
+		Labels:         grouping1,
+		Timestamp:      ts4,
+		MetricFamilies: metricFamiliesMap(mf1ts),
+		Done:           errCh,
+		Replace:        true,
+	})
+	err = nil
+	for err = range errCh {
+		if err != errTimestamp {
+			t.Errorf("Expected error %q, got %q.", errTimestamp, err)
+		}
+	}
+	if err == nil {
+		t.Error("Expected error on pushing metric with timestamp.")
+	}
+	pushFailedTimestamp = newPushFailedTimestampGauge(grouping1, ts4)
+	if err := checkMetricFamilies(
+		dms, mf2,
+		pushTimestamp, pushFailedTimestamp,
+	); err != nil {
+		t.Error(err)
+	}
+
+	// Push an empty map (rather than a nil map) in replace mode. Should
+	// delete everything except the push timestamps.
+	ts5 := ts4.Add(time.Second)
+	errCh = make(chan error, 1)
+	dms.SubmitWriteRequest(WriteRequest{
+		Labels:         grouping1,
+		Timestamp:      ts5,
+		MetricFamilies: metricFamiliesMap(),
+		Done:           errCh,
+		Replace:        true,
+	})
+	for err := range errCh {
+		t.Fatal("Unexpected error:", err)
+	}
+	pushTimestamp = newPushTimestampGauge(grouping1, ts5)
+	if err := checkMetricFamilies(
+		dms,
+		pushTimestamp, pushFailedTimestamp,
+	); err != nil {
+		t.Error(err)
+	}
+
+	if err := dms.Shutdown(); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestGetMetricFamiliesMap(t *testing.T) {
 	tempDir, err := ioutil.TempDir("", "diskmetricstore.TestGetMetricFamiliesMap.")
 	if err != nil {
@@ -740,7 +1322,7 @@ func TestGetMetricFamiliesMap(t *testing.T) {
 	}
 
 	labels2 := map[string]string{
-		"job":      "job2",
+		"job":      "job1",
 		"instance": "instance2",
 	}
 
@@ -749,34 +1331,52 @@ func TestGetMetricFamiliesMap(t *testing.T) {
 
 	// Submit a single simple metric family.
 	ts1 := time.Now()
+	errCh := make(chan error, 1)
 	dms.SubmitWriteRequest(WriteRequest{
 		Labels:         labels1,
 		Timestamp:      ts1,
-		MetricFamilies: map[string]*dto.MetricFamily{"mf3": mf3},
+		MetricFamilies: metricFamiliesMap(mf3),
+		Done:           errCh,
 	})
-	time.Sleep(20 * time.Millisecond) // Give loop() time to process.
-	if err := checkMetricFamilies(dms, mf3); err != nil {
+	for err := range errCh {
+		t.Fatal("Unexpected error:", err)
+	}
+	pushTimestamp := newPushTimestampGauge(labels1, ts1)
+	pushFailedTimestamp := newPushFailedTimestampGauge(labels1, time.Time{})
+	if err := checkMetricFamilies(
+		dms, mf3,
+		pushTimestamp, pushFailedTimestamp,
+	); err != nil {
 		t.Error(err)
 	}
 
 	// Submit two metric families for a different instance.
 	ts2 := ts1.Add(time.Second)
+	errCh = make(chan error, 1)
 	dms.SubmitWriteRequest(WriteRequest{
 		Labels:         labels2,
 		Timestamp:      ts2,
-		MetricFamilies: map[string]*dto.MetricFamily{"mf1": mf1b, "mf2": mf2},
+		MetricFamilies: metricFamiliesMap(mf1b, mf2),
+		Done:           errCh,
 	})
-	time.Sleep(20 * time.Millisecond) // Give loop() time to process.
+	for err := range errCh {
+		t.Fatal("Unexpected error:", err)
+	}
 
-	// expectedMFMap is a multi-layered map that maps the labelset fingerprints to the corresponding metric family string representations.
-	// This is for test assertion purposes.
+	// expectedMFMap is a multi-layered map that maps the labelset
+	// fingerprints to the corresponding metric family string
+	// representations.  This is for test assertion purposes.
 	expectedMFMap := map[uint64]map[string]string{
 		ls1: {
-			"mf3": mf3.String(),
+			"mf3":                mf3.String(),
+			pushMetricName:       pushTimestamp.String(),
+			pushFailedMetricName: pushFailedTimestamp.String(),
 		},
 		ls2: {
-			"mf1": mf1b.String(),
-			"mf2": mf2.String(),
+			"mf1":                mf1b.String(),
+			"mf2":                mf2.String(),
+			pushMetricName:       newPushTimestampGauge(labels2, ts2).String(),
+			pushFailedMetricName: newPushFailedTimestampGauge(labels2, time.Time{}).String(),
 		},
 	}
 
@@ -789,6 +1389,7 @@ func TestHelpStringFix(t *testing.T) {
 	dms := NewDiskMetricStore("", 100*time.Millisecond, prometheus.DefaultGatherer, logger)
 
 	ts1 := time.Now()
+	errCh := make(chan error, 1)
 	dms.SubmitWriteRequest(WriteRequest{
 		Labels: map[string]string{
 			"job": "job1",
@@ -807,13 +1408,16 @@ func TestHelpStringFix(t *testing.T) {
 		MetricFamilies: map[string]*dto.MetricFamily{
 			"mf_help": mfh2,
 		},
+		Done: errCh,
 	})
-	time.Sleep(20 * time.Millisecond) // Give loop() time to process.
+	for err := range errCh {
+		t.Fatal("Unexpected error:", err)
+	}
 
-	// Either we have settle on the mfh1 help string or the mfh2 help string.
+	// Either we have settled on the mfh1 help string or the mfh2 help string.
 	gotMFs := dms.GetMetricFamilies()
-	if len(gotMFs) != 2 {
-		t.Fatalf("expected 2 metric families, got %d", len(gotMFs))
+	if len(gotMFs) != 4 {
+		t.Fatalf("expected 4 metric families, got %d", len(gotMFs))
 	}
 	gotMFsAsStrings := make([]string, len(gotMFs))
 	for i, mf := range gotMFs {


### PR DESCRIPTION
This is finally a solution to #202 (and as a byproduct to #94).

The original wisdom used to be that checking pushed metrics during the
push should not be done because it is inherently an O(n\*m) problem: n
is the number of metrics in the PGW, and m is the number of pushes in
a certain time-frame. Upon each push, a check has to run, and that
check has a cost linear with the total number of metrics. Thus, if you
scale up something by a factor of 2, you can expect twice as many
pushers pushing in total twice as many metrics, in twice as many push
operations, resulting in 2\*2=4 times the cost of checking
metrics. Since we didn't want to let pushers wait for a potentially
expensive check, we just accepted the push, as long as it was
parseable, and deferred the error detection to scrapes.

The result was that a single inconsistent push would result in an
error when scraping the PGW. The bright side here is that the problem
will be spotted quite easily, and there is a strong incentive to fix
it. The problematic part is that a single rogue pusher is affecting
all systems that depend on the same PGW, possibly at inconvenient
times.

In sane use cases for the PGW, scrapes are happening more often than
pushes. Let's say a database backup pushes its success or failure
outcome once per day. Scrapes happen a couple of times per
minute. While the whole O(n*m) calculation above is not wrong, the
reality is that the scrapes will inflict the cost anyway. If the check
is too expensive per push, it will be even more so per scrape. Also,
pushers shouldn't be too sensitive to slightly enlarged push
times. Finally, if a PGW is so heavily loaded with metrics that the
check actually takes prohibitively long, we can be quite sure that
this PGW is abused for something it was not meant for (like turning
Prometheus into a push-based system).

The solution is conceptually quite easy: On each push, first feed the
push into a copy of the current metrics state (which has a certain
cost but it is anyway done whenever somebody looks at the web UI) and
then simulate a scrape. In that way, we can reuse the validation power
of prometheus/client_golang. We don't even need to rearchitecture the
whole framework of queueing pushes and deletions. We only need to talk
back via an optional channel. Pushes will now get a 200 or a 400
rathen than the "(almost) always 202" response we had before.

Easy, isn't it?

Unfortunately, the easy change became _way_ more invasive than I
anticipated. Here is an overview of the changes in this commit (also
see the changes in README.md, which explain the usage side of things):

- Previously, the PUT request was executed in two parts: First, delete
  all metrics in the group, then add the newly pushed metrics to the
  group. That's now a problem. If the 2nd part fails, it will leave
  behind an empty group rather than the state before the whole PUT
  request, as the user will certainly expect. Thus, the operation had
  to be made atomic. To accomplish that, the `storage.WriteRequest`
  now has an additional field `Replace` to mark replacement of the
  whole group if true. This field is in addition to the back channel
  mentioned above (called `Done` in the `WriteRequest`).

- To enable alerting on failed pushes, there is now a new metric
  `push_failure_time_seconds` with the timestamp of the last failed
  push (or 0 if there never was a failed push). Ideally, we would
  rename the existing metric `push_time_seconds` to
  `push_success_time_seconds`, but that would break all existing uses
  of that metric. Thus, I left the name as is, although
  `push_time_seconds` is only updated upon a successful push. (This
  allows alerting on `push_failure_time_seconds > push_time_seconds`
  and tracks at the same time the last successful push.) There are
  some subtle aspects of implementing this correctly, mostly around
  the problem that a successful push should leave a pre-existing
  failure timestamp intact and vice versa.

- Previously, the push handler code already had a bunch of validation
  and sanitation code (block timestamps, sanitize labels) and also
  added the `push_time_seconds` metric. Now that the storage layer is
  doing the consistency check for the pushed metric, it is way cleaner
  to have all the other validation and sanitation code there as
  well. (Arguably, it was already wrong to have too much logic in the
  push handler.) Also, the decision needed to properly set the
  `push_time_seconds` and `push_faiure_time_seconds` metrics can now
  only be made after the consistency check, so those metrics have to
  be set in the storage layer anyway. This change of responsibility
  also changed the tests quite a bit. The push handler tests now test
  only that the right method calls happen to the storage, while the
  many tests for validation, consistency checks, adding the push
  timestamp metrics, and proper sanitation are now part of the storage
  tests. (Digression: One might argue that the cleanest solution is a
  separate validation layer in front of a dumb storage layer. Since
  the only implementation of the storage for now is the disk storage
  (and a mock storage for testing), I decided to not make that split
  prematurely.)

- Logging of rejected pushes happens ot error level now. Strictly
  speaking, it is just a user error and not an error of the PGW
  itself, if it is happening. But experience tells us that users first
  check the logs, and they usualyl don't run on debug or even info
  level. I hope this will avoid a whole lot of user support questions.
  Groups where the last push has failed are also marked in the web UI.

Signed-off-by: beorn7 <beorn@grafana.com>