### PR TITLE
Avoid hash collisions in the storage by not hashing grouping labels

### DIFF
--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -16,6 +16,7 @@ package handler
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -580,7 +581,7 @@ func TestWipeMetricStore(t *testing.T) {
 	metricCount := 5
 	mgs := storage.GroupingKeyToMetricGroup{}
 	for i := 0; i < metricCount; i++ {
-		mgs[uint64(i)] = storage.MetricGroup{}
+		mgs[fmt.Sprint(i)] = storage.MetricGroup{}
 	}
 	mms := MockMetricStore{metricGroups: mgs}
 

--- a/storage/interface.go
+++ b/storage/interface.go
@@ -104,7 +104,7 @@ type WriteRequest struct {
 
 // GroupingKeyToMetricGroup is the first level of the metric store, keyed by
 // grouping key.
-type GroupingKeyToMetricGroup map[uint64]MetricGroup
+type GroupingKeyToMetricGroup map[string]MetricGroup
 
 // MetricGroup adds the grouping labels to a NameToTimestampedMetricFamilyMap.
 type MetricGroup struct {


### PR DESCRIPTION
Instead, simply put into a string what was hashed before and use that
string as the key in the map instead of the uint64 hash value used before.

Hashing was essentially done for convenience, ignoring the ill effect
of a hash collision, should it ever occur. In contrast to other uses
of hashing of label maps, the hashing isn't needed here for
performance reasons. Neither CPU cycles nor memory usage is critical
here.

The downside is that the on-disk format changes. This commit includes
code to convert the old format if encountered. This code is planned to
be removed prior to the v1 release of the PGW.

Note about testing the conversion: I have verified manually that it
works and was planning to add a test. However, that test would require
adding a fixture in the old format. As this code will be removed in
the next released, I decided it's not worth the
complication. (Automated tests are there to make sure things keep
working after code changes. In this case, the next change will be to
remove the code to be tested.)

Signed-off-by: beorn7 <beorn@grafana.com>