### PR TITLE
Enforce static conversion for common values

### DIFF
--- a/handler/status.go
+++ b/handler/status.go
@@ -67,6 +67,11 @@ func Status(
 			t := template.New("status")
 			t.Funcs(template.FuncMap{
 				"value": func(f float64) string {
+					if f == 0 {
+						return "0"
+					} else if f == 1 {
+						return "1"
+					}
 					return strconv.FormatFloat(f, 'f', -1, 64)
 				},
 				"timeFormat": func(t time.Time) string {


### PR DESCRIPTION
I've a pretty busy PG which `/` endpoints delivers 120MB of HTML data and takes forever to render.

Although pagination would be the correct answer to the problem, I'm wondering if using static conversion from float64 to string for most common values wouldn't save some CPU while rendering.

It's a page taken from the kube-state-metrics optimization book:

https://github.com/kubernetes/kube-state-metrics/blob/v1.8.0/pkg/metric/metric.go#L106-L109

Signed-off-by: Sylvain Rabot <s.rabot@lectra.com>