### PR TITLE
add DCO to contribution guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,3 +16,5 @@ Prometheus uses GitHub to manage reviews of pull requests.
   and the _Formatting and style_ section of Peter Bourgon's [Go: Best
   Practices for Production
   Environments](http://peter.bourgon.org/go-in-production/#formatting-and-style).
+
+* Be sure to sign off on the [DCO](https://github.com/probot/dco#how-it-works)


### PR DESCRIPTION
After @beorn7 said that the DCO is referenced in the contribution guides
of most Prometheus projects I noticed it was _not_ in the pushgateway so
here's a tiny update.

Signed-off-by: David Worth <dworth@strava.com>