### PR TITLE
Pull correct docker base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG ARCH="amd64"
 ARG OS="linux"
-FROM quay.io/prometheus/busybox:latest
+FROM quay.io/prometheus/busybox-${OS}-${ARCH}:latest
 LABEL maintainer="The Prometheus Authors <prometheus-developers@googlegroups.com>"
 
 ARG ARCH="amd64"


### PR DESCRIPTION
This fixes the problem, that the manifest list of `docker.io/prom/pushgateway` and `quay.io/repository/prometheus/pushgateway`contained the wrong architectures. The `amd64` and `armv7` manifest entries had the architecture set to `amd64`.
In case of a `docker pull` from a non-amd64 platform, the wrong image was pulled and the container failed.

By changing the base image of the Dockerfile to an image with correctly set architecture, the resulting image has the architecture set correctly as well.
@beorn7 