### PR TITLE
fix reject timestamps test

### DIFF
--- a/storage/diskmetricstore_test.go
+++ b/storage/diskmetricstore_test.go
@@ -978,7 +978,7 @@ func TestRejectTimestamps(t *testing.T) {
 	ts1 := time.Now()
 	grouping1 := map[string]string{
 		"job":      "job1",
-		"instance": "instance1",
+		"instance": "instance2",
 	}
 	errCh := make(chan error, 1)
 	dms.SubmitWriteRequest(WriteRequest{


### PR DESCRIPTION
though the value happens not to be examined, the test is using the wrong instance value