### PR TITLE
api: Make sure metrics endpoint starst with empty slice

### DIFF
--- a/api/v1/api.go
+++ b/api/v1/api.go
@@ -129,7 +129,7 @@ type metrics struct {
 
 func (api *API) metrics(w http.ResponseWriter, r *http.Request) {
 	familyMaps := api.MetricStore.GetMetricFamiliesMap()
-	var res []interface{}
+	res := []interface{}{}
 	for _, v := range familyMaps {
 		metricResponse := map[string]interface{}{}
 		metricResponse["labels"] = v.Labels


### PR DESCRIPTION
Previously, it used a nil slice, which is fine for Go, but creates
`null` rather than `[]` when marshaled to JSON.

@drumilpatel2000 this is the explanation for the TravisCI test behavior. Travis first merges the PR into master and then runs the tests, while CircleCI runs the tests in the branch from which the PR is coming.

I had performed some cleanups earlier, and this one was not exactly a no-op. Fixing it now.