### PR TITLE
Add scroll bars

### DIFF
--- a/resources/template.html
+++ b/resources/template.html
@@ -96,7 +96,7 @@ limitations under the License.
 			</h2>
 		</div>
 		<div id="m-{{$mCount}}" class="collapse" aria-labelledby="metric-panel-{{$mCount}}" data-parent="#metric-accordion-{{$gCount}}" >
-			<div class="card-body">
+			<div class="card-body" style="max-width: 100%; overflow-x: auto">
 				<table class="table table-striped table-bordered">
 					<thead>
 						<tr>


### PR DESCRIPTION
Signed-off-by: zhangwei <pknfe@outlook.com>

Add a scroll bar so that you can view the value even when the label is too long, such as metrics reported by Flink.

## Screen capture
![image](https://user-images.githubusercontent.com/26432832/83972771-a4f23c00-a914-11ea-9ee8-fb4201612fb6.png)