### PR TITLE
fix: issue #362: UI: Metrics text alignment issue on zoom

### DIFF
--- a/resources/template.html
+++ b/resources/template.html
@@ -86,7 +86,7 @@ limitations under the License.
 	<div class="card">
 		<div class="card-header" id="metric-panel-{{$mCount}}">
 			<h2 class="mb-0">
-				<button class="btn btn-secondary collapsed" type="button" data-toggle="collapse" data-target="#m-{{$mCount}}" aria-expanded="false" aria-controls="#m-{{$mCount}}">
+				<button class="btn btn-secondary collapsed" type="button" data-toggle="collapse" data-target="#m-{{$mCount}}" aria-expanded="false" aria-controls="#m-{{$mCount}}" style="text-align:left">
 					<span class="toggle-icon glyphicon glyphicon-collapse-down"></span>
 					{{- $name}}
 					<span class="badge badge-light">{{$tmf.GetMetricFamily.GetHelp}}</span>


### PR DESCRIPTION
Add style="text-align:left" to button in metric-panel