### PR TITLE
Web UI: Fix deletion of groups with empty label values

### DIFF
--- a/resources/static/functions.js
+++ b/resources/static/functions.js
@@ -48,7 +48,8 @@ pushgateway.deleteGroup = function(){
     for (var ln in pushgateway.labels) {
 	if (ln != 'job') {
 	    pathElements.push(encodeURIComponent(ln+'@base64'));
-	    pathElements.push(encodeURIComponent(pushgateway.labels[ln]));
+	    // Always add a padding '=' to ensure empty label values work.
+	    pathElements.push(encodeURIComponent(pushgateway.labels[ln]+'='));
 	}
     }
     var groupPath = pathElements.join('/');


### PR DESCRIPTION
If an empty label value ends up in the middle of the URL, it leads to
a double-`/`. The Pushgateway requires a single padding `=` character
to avoid the problem.

With this change, we simply always add the padding `=`. It's optional
and can be used at will even with non-empty label values.

Fixes #375.
@c0llins0