### PR TITLE
Fix Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,10 +5,10 @@ LABEL maintainer="The Prometheus Authors <prometheus-developers@googlegroups.com
 
 ARG ARCH="amd64"
 ARG OS="linux"
-COPY --chown=nobody:nogroup .build/${OS}-${ARCH}/pushgateway /bin/pushgateway
+COPY --chown=nobody:nobody .build/${OS}-${ARCH}/pushgateway /bin/pushgateway
 
 EXPOSE 9091
-RUN mkdir -p /pushgateway && chown nobody:nogroup /pushgateway
+RUN mkdir -p /pushgateway && chown nobody:nobody /pushgateway
 WORKDIR /pushgateway
 
 USER 65534


### PR DESCRIPTION
The new doker image has renamed nogroup to nobody

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>