### PR TITLE
Use relative paths for assets in template.html if no pathPrefix is set

### DIFF
--- a/handler/status.go
+++ b/handler/status.go
@@ -104,6 +104,10 @@ func Status(
 				"goVersion": version.GoVersion,
 			}
 
+			if pathPrefix == "" {
+				pathPrefix = "."
+			}
+
 			d := &data{
 				MetricGroups: ms.GetMetricFamiliesMap(),
 				BuildInfo:    buildInfo,


### PR DESCRIPTION
Loading the assets always from toplevel `/static` is not a good practice and breaks our setup (as we deploy the pushgateway with a reverse proxy to a subpath)

This PR defaults to relative paths which works for the status handler on `/` and `/status`

No behavior is changed for configurations with path prefix