### PR TITLE
Ensure requests are checked while draining

### DIFF
--- a/storage/diskmetricstore.go
+++ b/storage/diskmetricstore.go
@@ -253,7 +253,11 @@ func (dms *DiskMetricStore) loop(persistenceInterval time.Duration) {
 			for {
 				select {
 				case wr := <-dms.writeQueue:
-					dms.processWriteRequest(wr)
+					if dms.checkWriteRequest(wr) {
+						dms.processWriteRequest(wr)
+					} else {
+						dms.setPushFailedTimestamp(wr)
+					}
 				default:
 					dms.done <- dms.persist()
 					return

--- a/storage/diskmetricstore_test.go
+++ b/storage/diskmetricstore_test.go
@@ -551,7 +551,7 @@ var (
 			},
 		},
 	}
-	mfUnlaballed = &dto.MetricFamily{
+	mfUnlabelled = &dto.MetricFamily{
 		Name: proto.String("mf_unlabelled"),
 		Help: proto.String("Metric with no labels to check sanitizeLabels."),
 		Type: dto.MetricType_GAUGE.Enum(),
@@ -912,7 +912,7 @@ func TestAddDeletePersistRestore(t *testing.T) {
 	dms.SubmitWriteRequest(WriteRequest{
 		Labels:         grouping6,
 		Timestamp:      ts5,
-		MetricFamilies: testutil.MetricFamiliesMap(mfUnlaballed),
+		MetricFamilies: testutil.MetricFamiliesMap(mfUnlabelled),
 	})
 	if err := dms.Shutdown(); err != nil {
 		t.Fatal(err)
@@ -927,7 +927,7 @@ func TestAddDeletePersistRestore(t *testing.T) {
 		newPushFailedTimestampGauge(grouping5, time.Time{}).Metric[0],
 		newPushFailedTimestampGauge(grouping6, time.Time{}).Metric[0],
 	)
-	mfLaballed := proto.Clone(mfUnlaballed).(*dto.MetricFamily)
+	mfLaballed := proto.Clone(mfUnlabelled).(*dto.MetricFamily)
 	// sanitizeLabels should add these labels to the unlabelled metric
 	mfLaballed.Metric[0].Label = []*dto.LabelPair{
 		{

--- a/storage/diskmetricstore_test.go
+++ b/storage/diskmetricstore_test.go
@@ -927,9 +927,9 @@ func TestAddDeletePersistRestore(t *testing.T) {
 		newPushFailedTimestampGauge(grouping5, time.Time{}).Metric[0],
 		newPushFailedTimestampGauge(grouping6, time.Time{}).Metric[0],
 	)
-	mfLaballed := proto.Clone(mfUnlabelled).(*dto.MetricFamily)
-	// sanitizeLabels should add these labels to the unlabelled metric
-	mfLaballed.Metric[0].Label = []*dto.LabelPair{
+	mfLabelled := proto.Clone(mfUnlabelled).(*dto.MetricFamily)
+	// SanitizeLabels should add these labels to the unlabelled metric.
+	mfLabelled.Metric[0].Label = []*dto.LabelPair{
 		{
 			Name:  proto.String("instance"),
 			Value: proto.String("instance1"),
@@ -940,7 +940,7 @@ func TestAddDeletePersistRestore(t *testing.T) {
 		},
 	}
 	if err := checkMetricFamilies(
-		dms, mf1a, mf2, mf4, mfLaballed,
+		dms, mf1a, mf2, mf4, mfLabelled,
 		pushTimestamp, pushFailedTimestamp,
 	); err != nil {
 		t.Error(err)

--- a/storage/diskmetricstore_test.go
+++ b/storage/diskmetricstore_test.go
@@ -551,6 +551,19 @@ var (
 			},
 		},
 	}
+	mfUnlaballed = &dto.MetricFamily{
+		Name: proto.String("mf_unlabelled"),
+		Help: proto.String("Metric with no labels to check sanitizeLabels."),
+		Type: dto.MetricType_GAUGE.Enum(),
+		Metric: []*dto.Metric{
+			{
+				Label: []*dto.LabelPair{},
+				Gauge: &dto.Gauge{
+					Value: proto.Float64(42),
+				},
+			},
+		},
+	}
 )
 
 func addGroup(
@@ -892,17 +905,42 @@ func TestAddDeletePersistRestore(t *testing.T) {
 			MetricFamilies: testutil.MetricFamiliesMap(mf4),
 		})
 	}
+	grouping6 := map[string]string{
+		"job":      "job4",
+		"instance": "instance1",
+	}
+	dms.SubmitWriteRequest(WriteRequest{
+		Labels:         grouping6,
+		Timestamp:      ts5,
+		MetricFamilies: testutil.MetricFamiliesMap(mfUnlaballed),
+	})
 	if err := dms.Shutdown(); err != nil {
 		t.Fatal(err)
 	}
 	pushTimestamp.Metric = append(
-		pushTimestamp.Metric, newPushTimestampGauge(grouping5, ts5).Metric[0],
+		pushTimestamp.Metric,
+		newPushTimestampGauge(grouping5, ts5).Metric[0],
+		newPushTimestampGauge(grouping6, ts5).Metric[0],
 	)
 	pushFailedTimestamp.Metric = append(
-		pushFailedTimestamp.Metric, newPushFailedTimestampGauge(grouping5, time.Time{}).Metric[0],
+		pushFailedTimestamp.Metric,
+		newPushFailedTimestampGauge(grouping5, time.Time{}).Metric[0],
+		newPushFailedTimestampGauge(grouping6, time.Time{}).Metric[0],
 	)
+	mfLaballed := proto.Clone(mfUnlaballed).(*dto.MetricFamily)
+	// sanitizeLabels should add these labels to the unlabelled metric
+	mfLaballed.Metric[0].Label = []*dto.LabelPair{
+		{
+			Name:  proto.String("instance"),
+			Value: proto.String("instance1"),
+		},
+		{
+			Name:  proto.String("job"),
+			Value: proto.String("job4"),
+		},
+	}
 	if err := checkMetricFamilies(
-		dms, mf1a, mf2, mf4,
+		dms, mf1a, mf2, mf4, mfLaballed,
 		pushTimestamp, pushFailedTimestamp,
 	); err != nil {
 		t.Error(err)


### PR DESCRIPTION
Fix issue where pushes received when draining didn't get labels, resulting in pushgateway saving bad data to the persist file and then failing to serve /metrics on restart.

(Potentially it would also be possible for inconsistent data to be accepted here, but the more noticeable issue is the side-effect of `checkWriteRequest` calling `sanitizeLabels` doesn't happen, so no labels are added).