### PR TITLE
feat: add gzip support for /metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,6 +390,16 @@ guaranteed that the `DELETE` will be processed first (and vice versa).
 Deleting a grouping key without metrics is a no-op and will not result
 in an error.
 
+### Request compression
+
+The body of a POST or PUT request may be gzip-compressed. Add a header `Content-Encoding: gzip` to do so.
+
+Example:
+
+```
+echo "some_metric 3.14" | gzip | curl -H 'Content-Encoding: gzip' --data-binary @- http://pushgateway.example.org:9091/metrics/job/some_job
+```
+
 ## Admin API
 
 The Admin API provides administrative access to the Pushgateway, and must be

--- a/api/v1/api.go
+++ b/api/v1/api.go
@@ -20,9 +20,8 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
-	"github.com/prometheus/common/route"
-
 	dto "github.com/prometheus/client_model/go"
+	"github.com/prometheus/common/route"
 
 	"github.com/prometheus/pushgateway/handler"
 	"github.com/prometheus/pushgateway/storage"


### PR DESCRIPTION
## What is pr do ?

Let pushgateway server handle gzip content-encoding content.

## Tests

### Accept gzip

- server
<img width="901" alt="image" src="https://user-images.githubusercontent.com/961094/181230646-6a7e7ec7-772a-43c0-89cc-c6259c2ebbc3.png">


- client
<img width="898" alt="image" src="https://user-images.githubusercontent.com/961094/181230681-64251876-509d-494c-be1e-afd8306f771d.png">

### Forbid gzip

- server
<img width="901" alt="image" src="https://user-images.githubusercontent.com/961094/181230936-83422959-188a-4940-bc5d-a5232931ca2e.png">

- client
<img width="898" alt="image" src="https://user-images.githubusercontent.com/961094/181230912-7d930f5a-848a-4f6b-ab1a-8d519a4062dd.png">

