### PR TITLE
Remove ioutil

### DIFF
--- a/handler/status.go
+++ b/handler/status.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 	"html"
 	"html/template"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strconv"
 	"time"
@@ -82,7 +82,7 @@ func Status(
 				return
 			}
 			defer f.Close()
-			tpl, err := ioutil.ReadAll(f)
+			tpl, err := io.ReadAll(f)
 			if err != nil {
 				http.Error(w, err.Error(), http.StatusInternalServerError)
 				level.Error(logger).Log("msg", "error reading template.html", "err", err.Error())

--- a/handler/status_test.go
+++ b/handler/status_test.go
@@ -14,7 +14,7 @@
 package handler
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -44,7 +44,7 @@ func TestPathPrefixPresenceInPage(t *testing.T) {
 		t.Fatalf("Wanted status %d, got %d", http.StatusOK, w.Code)
 	}
 
-	rawBody, err := ioutil.ReadAll(w.Result().Body)
+	rawBody, err := io.ReadAll(w.Result().Body)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/storage/diskmetricstore.go
+++ b/storage/diskmetricstore.go
@@ -17,7 +17,6 @@ import (
 	"encoding/gob"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"sort"
@@ -403,7 +402,7 @@ func (dms *DiskMetricStore) persist() error {
 	if dms.persistenceFile == "" {
 		return nil
 	}
-	f, err := ioutil.TempFile(
+	f, err := os.CreateTemp(
 		path.Dir(dms.persistenceFile),
 		path.Base(dms.persistenceFile)+".in_progress.",
 	)

--- a/storage/diskmetricstore_test.go
+++ b/storage/diskmetricstore_test.go
@@ -15,7 +15,6 @@ package storage
 
 import (
 	"fmt"
-	"io/ioutil"
 	"math"
 	"os"
 	"path"
@@ -665,7 +664,7 @@ func TestGetMetricFamilies(t *testing.T) {
 }
 
 func TestAddDeletePersistRestore(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "diskmetricstore.TestAddDeletePersistRestore.")
+	tempDir, err := os.MkdirTemp("", "diskmetricstore.TestAddDeletePersistRestore.")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1327,7 +1326,7 @@ func TestReplace(t *testing.T) {
 }
 
 func TestGetMetricFamiliesMap(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "diskmetricstore.TestGetMetricFamiliesMap.")
+	tempDir, err := os.MkdirTemp("", "diskmetricstore.TestGetMetricFamiliesMap.")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
`ioutil` is deprecated from go1.16 (ref: https://go.dev/doc/go1.16#ioutil).
So removed them. (Exclude generated by vfsgen)

Signed-off-by: inosato <si17_21@yahoo.co.jp>