### PR TITLE
Add snappy encoding support for /metrics endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,12 +392,14 @@ in an error.
 
 ### Request compression
 
-The body of a POST or PUT request may be gzip-compressed. Add a header `Content-Encoding: gzip` to do so.
+The body of a POST or PUT request may be gzip- or snappy-compressed. Add a
+header `Content-Encoding: gzip` or `Content-Encoding: snappy` to do so.
 
-Example:
+Examples:
 
 ```bash
 echo "some_metric 3.14" | gzip | curl -H 'Content-Encoding: gzip' --data-binary @- http://pushgateway.example.org:9091/metrics/job/some_job
+echo "some_metric 3.14" | snzip | curl -H 'Content-Encoding: snappy' --data-binary @- http://pushgateway.example.org:9091/metrics/job/some_job
 ```
 
 ## Admin API

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/prometheus/pushgateway
 require (
 	github.com/go-kit/log v0.2.1
 	github.com/golang/protobuf v1.5.2
+	github.com/golang/snappy v0.0.4
 	github.com/matttproud/golang_protobuf_extensions v1.0.4
 	github.com/prometheus/client_golang v1.14.0
 	github.com/prometheus/client_model v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -154,6 +154,8 @@ github.com/golang/protobuf v1.5.1/go.mod h1:DopwsBzvsk0Fs44TXzsVbJyPhcCPeIwnvohx
 github.com/golang/protobuf v1.5.2 h1:ROPKBNFfQgOUMifHyP+KYbvpjbdoFNs+aK7DXlji0Tw=
 github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/golang/snappy v0.0.3/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
+github.com/golang/snappy v0.0.4 h1:yAGX7huGHXlcLOEtBnF4w7FQwA26wojNCwOYAEhLjQM=
+github.com/golang/snappy v0.0.4/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=


### PR DESCRIPTION
* Replace `gunzipRequest()` with `decodeRequest()` where the decoding-method is determined based on the "Content-Encoding" header in a switch statement.
* Add support for snappy-encoded HTTP bodies.

```sh
$ echo "some_metric 1" | curl --data-binary @- http://localhost:9091/metrics/job/myjob/instance/myinstance
$ curl http://localhost:9091/metrics/
# TYPE some_metric untyped
some_metric{instance="myinstance",job="myjob"} 1

$ echo "some_gziped_metric 2" | gzip | curl -H "Content-Encoding: gzip" --data-binary @- http://localhost:9091/metrics/job/myjob/instance/myinstance
$ curl http://localhost:9091/metrics/
# TYPE some_gzipped_metric untyped
some_gziped_metric{instance="myinstance",job="myjob"} 2

$ echo "some_snappied_metric 3" | snzip | curl -H 'Content-Encoding: snappy' --data-binary @- http://localhost:9091/metrics/job/myjob/instance/myinstance
$ curl http://localhost:9091/metrics/
# TYPE some_snappied_metric untyped
some_snappied_metric{instance="myinstance",job="myjob"} 3
```

Resolves #441 