### PR TITLE
Add org context to publishing pipelines

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,6 +29,7 @@ workflows:
             tags:
               only: /.*/
       - prometheus/publish_master:
+          context: org-context
           requires:
             - test
             - build
@@ -36,6 +37,7 @@ workflows:
             branches:
               only: master
       - prometheus/publish_release:
+          context: org-context
           requires:
             - test
             - build


### PR DESCRIPTION
We need to use the `org-context` in CircleCI to inherit the publishing credentials.