### PR TITLE
Keep record of unwinded containers on page refresh

### DIFF
--- a/resources/static/functions.js
+++ b/resources/static/functions.js
@@ -119,11 +119,21 @@ $(function () {
 	    .removeClass('glyphicon-collapse-down')
 	    .addClass('glyphicon-collapse-up');
 	event.stopPropagation();
+
+	localStorage.setItem("coll_" + this.id, true);
     })
     $('div.collapse').on('hide.bs.collapse', function (event) {
 	$(this).prev().find('span.toggle-icon')
 	    .removeClass('glyphicon-collapse-up')
 	    .addClass('glyphicon-collapse-down');
 	event.stopPropagation();
+
+	localStorage.setItem("coll_" + this.id, false);
     })
+
+    $("div.collapse").each(function() {
+	if (localStorage.getItem("coll_" + this.id) == "true") {
+	    $(this).collapse("show");
+	}
+    });
 })

--- a/resources/static/functions.js
+++ b/resources/static/functions.js
@@ -120,7 +120,7 @@ $(function () {
 	    .addClass('glyphicon-collapse-up');
 	event.stopPropagation();
 
-	localStorage.setItem("coll_" + this.id, true);
+	sessionStorage.setItem("coll_" + this.id, true);
     })
     $('div.collapse').on('hide.bs.collapse', function (event) {
 	$(this).prev().find('span.toggle-icon')
@@ -128,11 +128,11 @@ $(function () {
 	    .addClass('glyphicon-collapse-down');
 	event.stopPropagation();
 
-	localStorage.setItem("coll_" + this.id, false);
+	sessionStorage.setItem("coll_" + this.id, false);
     })
 
     $("div.collapse").each(function() {
-	if (localStorage.getItem("coll_" + this.id) == "true") {
+	if (sessionStorage.getItem("coll_" + this.id) == "true") {
 	    $(this).collapse("show");
 	}
     });


### PR DESCRIPTION
The solution retains a record of the currently un-collapsed container and unwinds it on a page refresh.
No extra refresh button and no live-update. 

The minor inconvenience of this solution is that on a page refresh the unwind animation plays.

[Screencast from 2023-10-02 18-40-31.webm](https://github.com/prometheus/pushgateway/assets/6261556/f0ac6de7-0364-425e-a947-81d4a737fcaa)


Helps #568