### PR TITLE
Optimize computeRoutePrefix

### DIFF
--- a/main.go
+++ b/main.go
@@ -251,15 +251,22 @@ func computeRoutePrefix(prefix string, externalURL *url.URL) string {
 	}
 
 	if prefix == "/" {
-		prefix = ""
+		return ""
 	}
 
-	if prefix != "" {
-		prefix = "/" + strings.Trim(prefix, "/")
+	// Ensure prefix starts with "/"
+	if !strings.HasPrefix(prefix, "/") {
+		prefix = "/" + prefix
+	}
+
+	// Ensure prefix does not end with "/"
+	if strings.HasSuffix(prefix, "/") {
+		prefix = strings.TrimSuffix(prefix, "/")
 	}
 
 	return prefix
 }
+
 
 // shutdownServerOnQuit shutdowns the provided server upon closing the provided
 // quitCh or upon receiving a SIGINT or SIGTERM.

--- a/main.go
+++ b/main.go
@@ -254,12 +254,12 @@ func computeRoutePrefix(prefix string, externalURL *url.URL) string {
 		return ""
 	}
 
-	// Ensure prefix starts with "/"
+	// Ensure prefix starts with "/".
 	if !strings.HasPrefix(prefix, "/") {
 		prefix = "/" + prefix
 	}
 
-	// Ensure prefix does not end with "/"
+	// Ensure prefix does not end with "/".
 	if strings.HasSuffix(prefix, "/") {
 		prefix = strings.TrimSuffix(prefix, "/")
 	}

--- a/main.go
+++ b/main.go
@@ -259,10 +259,7 @@ func computeRoutePrefix(prefix string, externalURL *url.URL) string {
 		prefix = "/" + prefix
 	}
 
-	// Ensure prefix does not end with "/".
-	if strings.HasSuffix(prefix, "/") {
-		prefix = strings.TrimSuffix(prefix, "/")
-	}
+	prefix = strings.TrimSuffix(prefix, "/")
 
 	return prefix
 }

--- a/main.go
+++ b/main.go
@@ -267,7 +267,6 @@ func computeRoutePrefix(prefix string, externalURL *url.URL) string {
 	return prefix
 }
 
-
 // shutdownServerOnQuit shutdowns the provided server upon closing the provided
 // quitCh or upon receiving a SIGINT or SIGTERM.
 func shutdownServerOnQuit(server *http.Server, quitCh <-chan struct{}, logger log.Logger) error {


### PR DESCRIPTION
Previously, computeRoutePrefix was adding a '/' to the start of the prefix and then removing it from the end, regardless of whether it was there or not. This resulted in unnecessary string operations. The updated function only adds or removes the '/' when necessary, improving efficiency. Additionally, the function now uses strings.HasPrefix and strings.HasSuffix for clearer intent and readability.