### PR TITLE
resources: for native histograms show String() output in the UI

### DIFF
--- a/handler/status.go
+++ b/handler/status.go
@@ -26,7 +26,9 @@ import (
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 
+	dto "github.com/prometheus/client_model/go"
 	"github.com/prometheus/common/version"
+	"github.com/prometheus/pushgateway/histogram"
 	"github.com/prometheus/pushgateway/storage"
 )
 
@@ -72,6 +74,16 @@ func Status(
 				},
 				"base64": func(s string) string {
 					return base64.RawURLEncoding.EncodeToString([]byte(s))
+				},
+				"formatHistogram": func(m *dto.Histogram) string {
+					h, fh := histogram.NewModelHistogram(m)
+					if h == nil {
+						return fh.String()
+					}
+					return h.String()
+				},
+				"add": func(x, y int) int {
+					return x + y
 				},
 			})
 

--- a/histogram/prometheus_model.go
+++ b/histogram/prometheus_model.go
@@ -132,16 +132,16 @@ func GetAPIFloatBuckets(h *model.FloatHistogram) []APIBucket[float64] {
 }
 
 func makeBucket[BC model.BucketCount](bucket model.Bucket[BC]) APIBucket[BC] {
-	boundaries := uint64(2) // Exclusive on both sides AKA open interval.
+	boundaries := uint64(2) // () Exclusive on both sides AKA open interval.
 	if bucket.LowerInclusive {
 		if bucket.UpperInclusive {
-			boundaries = 3 // Inclusive on both sides AKA closed interval.
+			boundaries = 3 // [] Inclusive on both sides AKA closed interval.
 		} else {
-			boundaries = 1 // Inclusive only on lower end AKA right open.
+			boundaries = 1 // [) Inclusive only on lower end AKA right open.
 		}
 	} else {
 		if bucket.UpperInclusive {
-			boundaries = 0 // Inclusive only on upper end AKA left open.
+			boundaries = 0 // (] Inclusive only on upper end AKA left open.
 		}
 	}
 	return APIBucket[BC]{

--- a/resources/template.html
+++ b/resources/template.html
@@ -53,7 +53,6 @@ limitations under the License.
 			</div>
 		</div>
 	</nav>
-	
 	<div class="container-fluid" id="metrics-div">
 		{{- $data := .}}
 		{{- if eq (index .Flags "web.enable-admin-api") "true"}}
@@ -140,22 +139,43 @@ limitations under the License.
 				</tr>
 			</table>
 			{{- else}}
+                        {{- $h := .Histogram}}
 			{{- with .Histogram}}
+                        {{- $numBuckets := len .Bucket}}
+                        {{- $numNBuckets := add (len .PositiveSpan) (len .NegativeSpan)}}
 			<table class="table table-striped table-bordered">
-				{{- range .Bucket}}
+                                {{- if gt $numNBuckets 0}}
 				<tr>
-					<th scope="row">Sample values &le; {{value .GetUpperBound}}</th>
-					<td>{{.GetCumulativeCount}}</td>
+                                    <th scope="row">Native Histogram representation</th>
+                                    <td>{{formatHistogram $h}}</td>
 				</tr>
-				{{- end}}
-				<tr>
-					<th scope="row">Total sample Count</th>
-					<td>{{.GetSampleCount}}</td>
-				</tr>
-				<tr>
-					<th scope="row">Sample Sum</th>
-					<td>{{value .GetSampleSum}}</td>
-				</tr>
+                                {{- end}}
+                                {{- if gt $numBuckets 0}}
+                                        {{- range .Bucket}}
+                                        <tr>
+                                                <th scope="row">Sample values &le; {{value .GetUpperBound}}</th>
+                                                <td>{{.GetCumulativeCount}}</td>
+                                        </tr>
+                                        {{- end}}
+                                        <tr>
+                                                <th scope="row">Total sample Count</th>
+                                                <td>{{.GetSampleCount}}</td>
+                                        </tr>
+                                        <tr>
+                                                <th scope="row">Sample Sum</th>
+                                                <td>{{value .GetSampleSum}}</td>
+                                        </tr>
+                                {{- end}}
+                                {{- if eq (add $numNBuckets $numBuckets) 0}}
+                                        <tr>
+                                                <th scope="row">Total sample Count</th>
+                                                <td>{{.GetSampleCount}}</td>
+                                        </tr>
+                                        <tr>
+                                                <th scope="row">Sample Sum</th>
+                                                <td>{{value .GetSampleSum}}</td>
+                                        </tr>
+                                {{- end}}
 			</table>
 			{{- end}}
 			{{- end}}


### PR DESCRIPTION
If a histogram has no classic buckets, assume its a native histogram and render the stringyfied version of it.

Fixes: #515 