### PR TITLE
Fix UTF-8 label names display in UI

### DIFF
--- a/handler/status.go
+++ b/handler/status.go
@@ -16,7 +16,6 @@ package handler
 import (
 	"encoding/base64"
 	"fmt"
-	"github.com/prometheus/common/model"
 	"html"
 	"html/template"
 	"io"
@@ -25,6 +24,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/prometheus/common/model"
 	"github.com/prometheus/common/version"
 
 	dto "github.com/prometheus/client_model/go"

--- a/handler/status.go
+++ b/handler/status.go
@@ -16,6 +16,7 @@ package handler
 import (
 	"encoding/base64"
 	"fmt"
+	"github.com/prometheus/common/model"
 	"html"
 	"html/template"
 	"io"
@@ -84,6 +85,12 @@ func Status(
 				},
 				"add": func(x, y int) int {
 					return x + y
+				},
+				"formatLabelName": func(s string) string {
+					if !model.LabelName(s).IsValidLegacy() {
+						return fmt.Sprintf("%q", s)
+					}
+					return s
 				},
 			})
 

--- a/resources/template.html
+++ b/resources/template.html
@@ -70,7 +70,7 @@ limitations under the License.
 					<span class="toggle-icon glyphicon glyphicon-collapse-down"></span>
 					{{- $metricGroup := .}}
 					{{- range $i, $ln := .SortedLabels}}
-					<span class="badge {{if eq $ln "job"}}badge-warning{{else if eq $ln "instance"}}badge-primary{{else}}badge-info{{end}}">{{$ln | formatLabelName}}="{{index $metricGroup.Labels $ln}}"</span>
+					<span class="badge {{if eq $ln "job"}}badge-warning{{else if eq $ln "instance"}}badge-primary{{else}}badge-info{{end}}">{{formatLabelName $ln}}="{{index $metricGroup.Labels $ln}}"</span>
 					{{- end}}
 				</button>
 				{{- if not $metricGroup.LastPushSuccess}}<span class="badge badge-pill badge-danger" role="alert">Last push failed!</span>{{end}}
@@ -108,7 +108,7 @@ limitations under the License.
 	<tr>
 		<td>
 			{{- range .Label}}
-			<span class="badge {{if eq .GetName "job"}}badge-warning{{else if eq .GetName "instance"}}badge-primary{{else}}badge-info{{end}}">{{.Name | formatLabelName}}="{{.GetValue}}"</span>
+			<span class="badge {{if eq .GetName "job"}}badge-warning{{else if eq .GetName "instance"}}badge-primary{{else}}badge-info{{end}}">{{formatLabelName .Name}}="{{.GetValue}}"</span>
 			{{- end}}
 		</td>
 		<td>

--- a/resources/template.html
+++ b/resources/template.html
@@ -70,7 +70,7 @@ limitations under the License.
 					<span class="toggle-icon glyphicon glyphicon-collapse-down"></span>
 					{{- $metricGroup := .}}
 					{{- range $i, $ln := .SortedLabels}}
-					<span class="badge {{if eq $ln "job"}}badge-warning{{else if eq $ln "instance"}}badge-primary{{else}}badge-info{{end}}">{{$ln}}="{{index $metricGroup.Labels $ln}}"</span>
+					<span class="badge {{if eq $ln "job"}}badge-warning{{else if eq $ln "instance"}}badge-primary{{else}}badge-info{{end}}">{{$ln | formatLabelName}}="{{index $metricGroup.Labels $ln}}"</span>
 					{{- end}}
 				</button>
 				{{- if not $metricGroup.LastPushSuccess}}<span class="badge badge-pill badge-danger" role="alert">Last push failed!</span>{{end}}
@@ -108,7 +108,7 @@ limitations under the License.
 	<tr>
 		<td>
 			{{- range .Label}}
-			<span class="badge {{if eq .GetName "job"}}badge-warning{{else if eq .GetName "instance"}}badge-primary{{else}}badge-info{{end}}">{{.Name}}="{{.GetValue}}"</span>
+			<span class="badge {{if eq .GetName "job"}}badge-warning{{else if eq .GetName "instance"}}badge-primary{{else}}badge-info{{end}}">{{.Name | formatLabelName}}="{{.GetValue}}"</span>
 			{{- end}}
 		</td>
 		<td>


### PR DESCRIPTION
As a follow-up to https://github.com/prometheus/pushgateway/pull/689, this PR fixes how label names containing UTF-8 characters are displayed in the Pushgateway UI, double-quoting the label names and escaping double quotes within them.

![image](https://github.com/user-attachments/assets/50d4ce8e-b20f-4395-af68-0a17cc6e36ae)


Related to https://github.com/prometheus/pushgateway/issues/623