### PR TITLE
ci: pin contents: read on the CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
     branches: [master, 'release-*']
     tags: ['v*']
 
+permissions:
+  contents: read
+
 jobs:
   test_go:
     name: Go tests


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` to read-only for `ci.yml`. Image push (Docker Hub / Quay) and release publication use their own dedicated secrets (`docker_hub_login`/`docker_hub_password`, `quay_io_login`/`quay_io_password`, and the prom-bot PAT for releases), so the default token only needs read access for the checkout. Matches the top-level pattern in the other prometheus repos.