### PR TITLE
ci: cap `GITHUB_TOKEN` to `contents: read`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
     branches: [master, 'release-*']
     tags: ['v*']
 
+permissions:
+  contents: read
+
 jobs:
   test_go:
     name: Go tests


### PR DESCRIPTION
The `ci` workflow runs Go build / test only. No GitHub API writes, so workflow-level `contents: read` is the right cap for the default `GITHUB_TOKEN`.

Post-CVE-2025-30066 (`tj-actions/changed-files`) hardening pattern. YAML validated locally.