### PR TITLE
Migrate from github.com/golang/protobuf to google.golang.org/protobuf

### DIFF
--- a/api/v1/api_test.go
+++ b/api/v1/api_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 The Prometheus Authors
+// Copyright The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -21,9 +21,8 @@ import (
 	"testing"
 	"time"
 
-	//nolint:staticcheck // Ignore SA1019. Dependencies use the deprecated package, so we have to, too.
-	"github.com/golang/protobuf/proto"
 	"github.com/prometheus/common/promslog"
+	"google.golang.org/protobuf/proto"
 
 	dto "github.com/prometheus/client_model/go"
 
@@ -214,7 +213,9 @@ func TestStatusAPI(t *testing.T) {
 
 	testResponse := response{}
 	testAPI.status(w, req)
-	json.Unmarshal(w.Body.Bytes(), &testResponse)
+	if err := json.Unmarshal(w.Body.Bytes(), &testResponse); err != nil {
+		t.Fatalf("unexpected error unmarshaling response: %v", err)
+	}
 	jsonData := testResponse.Data.(map[string]any)
 	responseFlagData := jsonData["flags"].(map[string]any)
 	responseBuildInfo := jsonData["build_information"].(map[string]any)

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.25.0
 
 require (
 	github.com/alecthomas/kingpin/v2 v2.4.0
-	github.com/golang/protobuf v1.5.4
 	github.com/golang/snappy v1.0.0
 	github.com/prometheus/client_golang v1.23.2
 	github.com/prometheus/client_model v0.6.2

--- a/go.sum
+++ b/go.sum
@@ -14,8 +14,6 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63YCY=
 github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
-github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=
-github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
 github.com/golang/snappy v1.0.0 h1:Oy607GVXHs7RtbggtPBnr2RmDArIsAefDwvrdWvRhGs=
 github.com/golang/snappy v1.0.0/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=

--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -957,21 +957,18 @@ func TestWipeMetricStore(t *testing.T) {
 	}
 }
 
-// verifyMetricFamily jumps through a few hoops because the current protobuf
-// implementation is deliberately creating an unstable formatting for the text
-// representation. So this takes the text representation of the expected
-// MetricFamily and unmarshals it into a proto message object first. Then it
-// marshals both the expected and the got proto message into a binary protobuf,
-// which it then compares.
+// verifyMetricFamily compares a MetricFamily against an expected text-format
+// representation. It unmarshals expText into a proto message first, then
+// marshals both sides to binary to avoid instability in the text representation.
 func verifyMetricFamily(t *testing.T, expText string, got *dto.MetricFamily) {
+	t.Helper()
 	gotProto, err := proto.Marshal(got)
 	if err != nil {
 		t.Errorf("unexpected error marshaling MetricFamily %v", got)
 	}
 
 	exp := &dto.MetricFamily{}
-	err = prototext.Unmarshal([]byte(expText), exp)
-	if err != nil {
+	if err := prototext.Unmarshal([]byte(expText), exp); err != nil {
 		t.Errorf("unexpected error unmarshaling MetricFamily text %v", expText)
 	}
 	expProto, err := proto.Marshal(exp)
@@ -979,7 +976,7 @@ func verifyMetricFamily(t *testing.T, expText string, got *dto.MetricFamily) {
 		t.Errorf("unexpected error marshaling MetricFamily %v", exp)
 	}
 
-	if !bytes.Equal(expProto, gotProto) {
+	if string(expProto) != string(gotProto) {
 		t.Errorf("Wanted metric family %v, got %v.", exp, got)
 	}
 }

--- a/storage/diskmetricstore.go
+++ b/storage/diskmetricstore.go
@@ -26,11 +26,10 @@ import (
 	"sync"
 	"time"
 
-	//nolint:staticcheck // Ignore SA1019. Dependencies use the deprecated package, so we have to, too.
-	"github.com/golang/protobuf/proto"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/common/promslog"
+	"google.golang.org/protobuf/proto"
 
 	dto "github.com/prometheus/client_model/go"
 )

--- a/storage/diskmetricstore_test.go
+++ b/storage/diskmetricstore_test.go
@@ -22,8 +22,8 @@ import (
 	"testing"
 	"time"
 
-	//nolint:staticcheck // Ignore SA1019. Dependencies use the deprecated package, so we have to, too.
-	"github.com/golang/protobuf/proto"
+	"google.golang.org/protobuf/proto"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/common/promslog"

--- a/storage/interface.go
+++ b/storage/interface.go
@@ -17,8 +17,7 @@ import (
 	"sort"
 	"time"
 
-	//nolint:staticcheck // Ignore SA1019. Dependencies use the deprecated package, so we have to, too.
-	"github.com/golang/protobuf/proto"
+	"google.golang.org/protobuf/proto"
 
 	dto "github.com/prometheus/client_model/go"
 )

--- a/testutil/metric_families.go
+++ b/testutil/metric_families.go
@@ -1,4 +1,4 @@
-// Copyright 2020 The Prometheus Authors
+// Copyright The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -13,8 +13,7 @@
 package testutil
 
 import (
-	//nolint:staticcheck // Ignore SA1019. Dependencies use the deprecated package, so we have to, too.
-	"github.com/golang/protobuf/proto"
+	"google.golang.org/protobuf/proto"
 
 	dto "github.com/prometheus/client_model/go"
 )


### PR DESCRIPTION
The github.com/golang/protobuf package is deprecated in favor of google.golang.org/protobuf. Remove the dependency and update all import sites accordingly.

Also update dependencies.