### PR TITLE
Add distroless Docker image variant

### DIFF
--- a/Dockerfile.distroless
+++ b/Dockerfile.distroless
@@ -1,0 +1,26 @@
+ARG DISTROLESS_ARCH="amd64"
+
+# Use DISTROLESS_ARCH for base image selection (handles armv7->arm mapping).
+FROM gcr.io/distroless/static-debian13:nonroot-${DISTROLESS_ARCH}
+# Base image sets USER to 65532:65532 (nonroot user).
+# When using --persistence.file, mount a volume owned by uid 65532.
+
+ARG ARCH="amd64"
+ARG OS="linux"
+
+LABEL org.opencontainers.image.authors="The Prometheus Authors"
+LABEL org.opencontainers.image.vendor="Prometheus"
+LABEL org.opencontainers.image.title="Pushgateway"
+LABEL org.opencontainers.image.description="Push acceptor allowing ephemeral and batch jobs to expose their metrics to Prometheus."
+LABEL org.opencontainers.image.source="https://github.com/prometheus/pushgateway"
+LABEL org.opencontainers.image.url="https://github.com/prometheus/pushgateway"
+LABEL org.opencontainers.image.documentation="https://github.com/prometheus/pushgateway"
+LABEL org.opencontainers.image.licenses="Apache License 2.0"
+LABEL io.prometheus.image.variant="distroless"
+
+COPY LICENSE NOTICE /
+COPY .build/${OS}-${ARCH}/pushgateway /bin/pushgateway
+
+WORKDIR /pushgateway
+EXPOSE 9091
+ENTRYPOINT [ "/bin/pushgateway" ]


### PR DESCRIPTION
Uses gcr.io/distroless/static-debian13:nonroot as base image instead of busybox, reducing attack surface.